### PR TITLE
feat(): add pTo promise wrapper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,7 @@ import { pProps } from './promise/pProps'
 import { pRetry, PRetryOptions } from './promise/pRetry'
 import { pState } from './promise/pState'
 import { pTimeout, PTimeoutOptions } from './promise/pTimeout'
+import {pTo} from './promise/pTo'
 import { StringifyAnyOptions, _jsonParseIfPossible, _stringifyAny } from './string/json.util'
 import {
   _capitalize,
@@ -294,6 +295,7 @@ export {
   AggregatedError,
   pRetry,
   pTimeout,
+  pTo,
   _Retry,
   _Timeout,
   _tryCatch,

--- a/src/promise/pTo.test.ts
+++ b/src/promise/pTo.test.ts
@@ -1,0 +1,30 @@
+import { pTo } from './pTo'
+
+const FailingPromise = new Promise((resolve, reject) => {
+  reject(new Error('FAILED'))
+})
+
+const ResolvingPromise = new Promise<boolean>(resolve => {
+  resolve(true)
+})
+
+test('TO should catch async errors', async () => {
+  const [error] = await pTo(FailingPromise)
+
+  expect(!!error).toBe(true)
+  expect(error instanceof Error).toBe(true)
+})
+
+test('TO should not have result when catching error', async () => {
+  const [error, result] = await pTo(FailingPromise)
+
+  expect(error instanceof Error).toBe(true)
+  expect(!!result).toBe(false)
+})
+
+test('TO should pass the result to the second element of the tuple', async () => {
+  const [error, result] = await pTo(ResolvingPromise)
+
+  expect(error).toBe(null)
+  expect(result).toBe(true)
+})

--- a/src/promise/pTo.ts
+++ b/src/promise/pTo.ts
@@ -1,0 +1,26 @@
+/**
+ *
+ * Wraps async calls in try catch blocks
+ * to simplify syntax.
+ *
+ * source: https://github.com/scopsy/await-to-js/blob/master/src/await-to-js.ts
+ *
+ * @param { Promise } promise
+ * @param { Object= } errorExt - Additional Information you can pass to the err object
+ * @return { Promise } Tuple with error or response
+ */
+ export async function pTo<T, U = Error>(
+    promise: Promise<T>,
+    errorExt?: object,
+  ): Promise<[U, undefined] | [null, T]> {
+    return promise
+      .then<[null, T]>((data: T) => [null, data])
+      .catch<[U, undefined]>((err: U) => {
+        if (errorExt) {
+          Object.assign(err, errorExt)
+        }
+  
+        return [err, undefined]
+      })
+  }
+  


### PR DESCRIPTION
If merged, this PR will add "await-to-js"-like functionality to wrap async code in try-catch blocks and return tuples