### PR TITLE
perf(): replace range Array.from with for loop

### DIFF
--- a/scripts/rangeBench.ts
+++ b/scripts/rangeBench.ts
@@ -16,7 +16,7 @@ function _range(fromIncl: number, toExcl?: number, step = 1): number[] {
 function _rangeWithFor(fromIncl: number, toExcl?: number, step = 1): number[] {
   const arr = []
   if (toExcl === undefined) {
-    for (let i = fromIncl; i < fromIncl; i++) {
+    for (let i = 0; i < fromIncl; i++) {
       arr.push(i)
     }
   } else {

--- a/scripts/rangeBench.ts
+++ b/scripts/rangeBench.ts
@@ -1,0 +1,46 @@
+import { runBenchScript } from '@naturalcycles/bench-lib'
+
+/* eslint-disable unicorn/no-new-array */
+// 'old' range
+function _range(fromIncl: number, toExcl?: number, step = 1): number[] {
+  if (toExcl === undefined) {
+    return Array.from(new Array(fromIncl), (_, i) => i)
+  }
+
+  return Array.from(
+    { length: Math.ceil((toExcl - fromIncl) / step) },
+    (_, i) => i * step + fromIncl,
+  )
+}
+
+function _rangeWithFor(fromIncl: number, toExcl?: number, step = 1): number[] {
+  const arr = []
+  if (toExcl === undefined) {
+    for (let i = fromIncl; i < fromIncl; i++) {
+      arr.push(i)
+    }
+  } else {
+    for (let i = fromIncl; i < toExcl; i += step) {
+      arr.push(i)
+    }
+  }
+  return arr
+}
+
+function bench(): void {
+  runBenchScript({
+    fns: {
+      range: done => {
+        _range(0, 100, 1)
+        done.resolve()
+      },
+      rangeWithFor: done => {
+        _rangeWithFor(0, 100, 1)
+        done.resolve()
+      },
+    },
+    runs: 5,
+  })
+}
+
+bench()

--- a/src/array/range.ts
+++ b/src/array/range.ts
@@ -16,14 +16,17 @@ import { Iterable2 } from '../iter/iterable2'
 export function _range(toExcl: number): number[]
 export function _range(fromIncl: number, toExcl: number, step?: number): number[]
 export function _range(fromIncl: number, toExcl?: number, step = 1): number[] {
+  const arr = []
   if (toExcl === undefined) {
-    return Array.from(new Array(fromIncl), (_, i) => i)
+    for (let i = 0; i < fromIncl; i++) {
+      arr.push(i)
+    }
+  } else {
+    for (let i = fromIncl; i < toExcl; i += step) {
+      arr.push(i)
+    }
   }
-
-  return Array.from(
-    { length: Math.ceil((toExcl - fromIncl) / step) },
-    (_, i) => i * step + fromIncl,
-  )
+  return arr
 }
 
 /**


### PR DESCRIPTION
Here is the svg from runBench, png-ified:

![runBench](https://github.com/NaturalCycles/js-lib/assets/53127288/dd4627e4-fb60-4dfb-90a4-0a95263070b3)

I think the end result is still clean and readable so I don't see any real downside to it.