### PR TITLE
fix(Object): fix `_pick` and `_omit` return type

### DIFF
--- a/src/http/fetcher.model.ts
+++ b/src/http/fetcher.model.ts
@@ -127,7 +127,7 @@ export interface FetcherRequest
   timeoutSeconds: number
   retry: FetcherRetryOptions
   retryPost: boolean
-  retry3xx: boolean
+  retry3xx?: boolean
   retry4xx: boolean
   retry5xx: boolean
   started: UnixTimestampMillisNumber

--- a/src/http/fetcher.ts
+++ b/src/http/fetcher.ts
@@ -575,7 +575,7 @@ export class Fetcher {
     if (statusFamily === 3 && !retry3xx) return false
 
     // should not retry on `unexpected redirect` in error.cause.cause
-    if ((res.err?.cause as ErrorLike | void)?.cause?.message?.includes('unexpected redirect')) {
+    if ((res.err?.cause as ErrorLike)?.cause?.message?.includes('unexpected redirect')) {
       return false
     }
 

--- a/src/object/object.util.ts
+++ b/src/object/object.util.ts
@@ -11,7 +11,7 @@ export function _pick<T extends AnyObject, K extends keyof T>(
   obj: T,
   props: readonly K[],
   mutate = false,
-): T {
+): Pick<T, K> {
   if (mutate) {
     // Start as original object (mutable), DELETE properties that are not whitelisted
     return Object.keys(obj).reduce((r, prop) => {
@@ -34,7 +34,7 @@ export function _omit<T extends AnyObject, K extends keyof T>(
   obj: T,
   props: readonly K[],
   mutate = false,
-): T {
+): Omit<T, K> {
   return props.reduce(
     (r, prop) => {
       delete r[prop]

--- a/src/object/object.util.ts
+++ b/src/object/object.util.ts
@@ -360,7 +360,6 @@ export function _set<T extends AnyObject>(obj: T, path: PropertyPath, value: any
           a[c]
         : // No: create the key. Is the next key a potential array-index?
           (a[c] =
-            // @ts-expect-error
             // eslint-disable-next-line
             Math.abs(path[i + 1]) >> 0 === +path[i + 1]
               ? [] // Yes: assign a new array object

--- a/src/object/object.util.ts
+++ b/src/object/object.util.ts
@@ -360,6 +360,7 @@ export function _set<T extends AnyObject>(obj: T, path: PropertyPath, value: any
           a[c]
         : // No: create the key. Is the next key a potential array-index?
           (a[c] =
+            // @ts-expect-error
             // eslint-disable-next-line
             Math.abs(path[i + 1]) >> 0 === +path[i + 1]
               ? [] // Yes: assign a new array object

--- a/src/object/sortObject.ts
+++ b/src/object/sortObject.ts
@@ -1,5 +1,5 @@
 import type { AnyObject } from '../index'
-import { _omit } from '../index'
+import { _omit, _objectEntries } from '../index'
 
 /**
  * Returns new object with keys sorder in the given order.
@@ -15,7 +15,7 @@ export function _sortObject<T extends AnyObject>(obj: T, keyOrder: (keyof T)[]):
     }
   })
 
-  Object.entries(_omit(obj, keyOrder)).forEach(([k, v]) => {
+  _objectEntries(_omit(obj, keyOrder)).forEach(([k, v]) => {
     r[k as keyof T] = v
   })
 


### PR DESCRIPTION
In this PR, I have modified the return type of `_pick` and `_omit` to use `Pick<K, T>` and `Omit<K, T>` respectively.