### PR TITLE
feat(localDate): add `dayOfWeek`

### DIFF
--- a/src/datetime/localDate.test.ts
+++ b/src/datetime/localDate.test.ts
@@ -297,3 +297,14 @@ test('parse weird input', () => {
   expect(LocalDate.parseOrNull(Date.now() as any)).toBeNull()
   expect(LocalDate.parseOrNull((() => {}) as any)).toBeNull()
 })
+
+test('dayOfWeek', () => {
+  expect(localDate('1984-06-18').dayOfWeek()).toBe(1)
+  expect(localDate('1984-06-19').dayOfWeek()).toBe(2)
+  expect(localDate('1984-06-20').dayOfWeek()).toBe(3)
+  expect(localDate('1984-06-21').dayOfWeek()).toBe(4)
+  expect(localDate('1984-06-22').dayOfWeek()).toBe(5)
+  expect(localDate('1984-06-23').dayOfWeek()).toBe(6)
+  expect(localDate('1984-06-24').dayOfWeek()).toBe(7)
+  expect(localDate('1984-06-25').dayOfWeek()).toBe(1)
+})

--- a/src/datetime/localDate.ts
+++ b/src/datetime/localDate.ts
@@ -9,7 +9,7 @@ import type {
   UnixTimestampMillisNumber,
   UnixTimestampNumber,
 } from '../types'
-import { LocalTime } from './localTime'
+import { ISODayOfWeek, LocalTime } from './localTime'
 
 export type LocalDateUnit = LocalDateUnitStrict | 'week'
 export type LocalDateUnitStrict = 'year' | 'month' | 'day'
@@ -175,6 +175,10 @@ export class LocalDate {
   day(v: number): LocalDate
   day(v?: number): number | LocalDate {
     return v === undefined ? this.$day : this.set('day', v)
+  }
+
+  dayOfWeek(): ISODayOfWeek {
+    return (this.toDate().getDay() || 7) as ISODayOfWeek
   }
 
   isSame(d: LocalDateInput): boolean {


### PR DESCRIPTION
In this PR, I have added the `dayOfWeek` function to the `LocalDate`.
This is because in AMG3, we sometimes need to know whether the date is on the weekend, and currently we need to use `Date` for this.

Because `dayOfWeek` is already implemented for `LocalTime`, I used the same implementation.

However, I have not implemented the _setter_, because:
- it was not a pain point in AMG3
- and I find it hard to reason about _setting_ the day of week for an existing date. The user would need to remember or check the implementation to know if this moves the date forward or backward.

If we should add the setter for the sake of symmetry, let me know.