### PR TITLE
feat: add abortable `_find` and `_findLast`

### DIFF
--- a/src/array/array.util.test.ts
+++ b/src/array/array.util.test.ts
@@ -1,6 +1,6 @@
 import { _createDeterministicRandom } from '../number/createDeterministicRandom'
 import { _deepFreeze } from '../object/object.util'
-import { Mapper } from '../types'
+import { END, Mapper } from '../types'
 import {
   _by,
   _chunk,
@@ -9,6 +9,7 @@ import {
   _difference,
   _dropRightWhile,
   _dropWhile,
+  _find,
   _findLast,
   _first,
   _groupBy,
@@ -157,8 +158,14 @@ test('_sortBy with mutation', () => {
   expect(r).toBe(a)
 })
 
+test('_find', () => {
+  expect(_find([1, 2, 3, 4], n => n % 2 === 0)).toBe(2)
+  expect(_find([1, 2, 3, 4], n => (n === 2 ? END : false))).toBeUndefined()
+})
+
 test('_findLast', () => {
   expect(_findLast([1, 2, 3, 4], n => n % 2 === 1)).toBe(3)
+  expect(_findLast([1, 2, 3, 4], n => (n === 2 ? END : false))).toBeUndefined()
 })
 
 test('_takeWhile', () => {

--- a/src/array/array.util.ts
+++ b/src/array/array.util.ts
@@ -195,13 +195,27 @@ export function _sortDescBy<T>(items: T[], mapper: Mapper<T, any>, mutate = fals
 }
 
 /**
- * Like items.find(), but it tries to find from the END of the array.
+ * Similar to `Array.find`, but the `predicate` may return `END` to stop the iteration early.
  *
- * Node 18+ supports native array.findLast() - use that.
- * iOS Safari only has it since 15.4
+ * Use `Array.find` if you don't need to stop the iteration early.
  */
-export function _findLast<T>(items: T[], predicate: Predicate<T>): T | undefined {
-  return [...items].reverse().find(predicate)
+export function _find<T>(items: T[], predicate: AbortablePredicate<T>): T | undefined {
+  for (const [i, item] of items.entries()) {
+    const result = predicate(item, i)
+    if (result === END) return
+    if (result) return item
+  }
+}
+
+/**
+ * Similar to `Array.findLast`, but the `predicate` may return `END` to stop the iteration early.
+ *
+ * Use `Array.findLast` if you don't need to stop the iteration early, which is supported:
+ * - in Node since 18+
+ * - in iOS Safari since 15.4
+ */
+export function _findLast<T>(items: T[], predicate: AbortablePredicate<T>): T | undefined {
+  return _find(items.slice().reverse(), predicate)
 }
 
 export function _takeWhile<T>(items: T[], predicate: Predicate<T>): T[] {


### PR DESCRIPTION
In this PR, I have added a `_find` function with `AbortablePredicate`,
and refactored `_findLast` to use `_find`.