### PR TITLE
feat: _stringifyOrUndefined

### DIFF
--- a/src/string/stringify.ts
+++ b/src/string/stringify.ts
@@ -192,6 +192,17 @@ export const _stringifyAny = _stringify
 
 /**
  * Stringifies an object using `_stringify, but returns `undefined` if the object is `undefined`.
+ * Useful when we want to have a custom stringification of an undefined object,
+ * which is not `'undefined'`.
+ *
+ * Example:
+ * ```ts
+ * let a: string | undefined = "hello"
+ * _stringifyOrUndefined(a) || "default value" // => '"hello"'
+ * a = undefined
+ * _stringifyOrUndefined(a || "default value") // => '"default value"'
+ * _stringifyOrUndefined(a) || "default value"// => 'default value'
+ * ```
  */
 export function _stringifyOrUndefined(obj: any, opt: StringifyOptions = {}): string | undefined {
   return obj === undefined ? undefined : _stringify(obj, opt)

--- a/src/string/stringify.ts
+++ b/src/string/stringify.ts
@@ -189,3 +189,10 @@ export function _stringify(obj: any, opt: StringifyOptions = {}): string {
  * @deprecated renamed to _stringify
  */
 export const _stringifyAny = _stringify
+
+/**
+ * Stringifies an object using `_stringify, but returns `undefined` if the object is `undefined`.
+ */
+export function _stringifyOrUndefined(obj: any, opt: StringifyOptions = {}): string | undefined {
+  return obj === undefined ? undefined : _stringify(obj, opt)
+}


### PR DESCRIPTION
Add a helper function to be able to set custom default values on a `_stringify`-ed object, if the object is `undefined`

This will be used to send `NotAnswered` as a custom value to the Optimove API, and to avoid having to do something like 
```ts
_stringify(obj || 'NotAnswered') // => "\"NotAnswered\""
```

`merge-on-green`