### PR TITLE
Add todayStringNoHyphens()

### DIFF
--- a/src/datetime/localDate.test.ts
+++ b/src/datetime/localDate.test.ts
@@ -352,6 +352,13 @@ test('todayString', () => {
   expect(s < '2099-01-01').toBe(true)
 })
 
+test('todayStringNoHyphens', () => {
+  const s = todayString()
+  expect(s.startsWith(new Date().getFullYear())).toBe(true)
+  expect(s > '2024-05-01').toBe(true)
+  expect(s < '2099-01-01').toBe(true)
+})
+
 test('todayString tz', () => {
   if (isUTC()) return
   console.log(process.env['TZ'])

--- a/src/datetime/localDate.ts
+++ b/src/datetime/localDate.ts
@@ -751,3 +751,13 @@ Object.setPrototypeOf(localDate, localDateFactory)
 export function todayString(): IsoDateString {
   return localDate.fromDate(new Date()).toISODate()
 }
+
+/**
+ Convenience function to return current today's IsoDateString representation formatted with no hyphens, e.g `20240613`
+ */
+export function todayStringNoHyphens(): IsoDateString {
+  const date = new Date();
+  const ymd = date.toISOString().split('T')[0].split('-');
+  const date_formatted = `${ymd[0]}${ymd[1]}${ymd[2]}`
+  return date_formatted
+}


### PR DESCRIPTION
todayStringNoHyphens() will return today's date in the following format: '20240617'
This is needed, so that the apple-watch logs end up in the same file/date format as the other files from the gcs-nc-snapshots bucket. At the moment, this is how the file formats look like:
algo-data/algoDataLH_20240603.ndjson.gz
algo-data/full_20240601.ndjson.gz
algo-ondemand/oura_20240529.ndjson
apple-watch/appleWatchSnapshot_2024-06-10.ndjson.gz