### PR TITLE
feat: generic number types for sum helpers

### DIFF
--- a/src/array/array.util.ts
+++ b/src/array/array.util.ts
@@ -347,23 +347,26 @@ export function _difference<T>(a1: T[], a2: T[] | Set<T>): T[] {
 /**
  * Returns the sum of items, or 0 for empty array.
  */
-export function _sum(items: Iterable<number>): number {
-  let sum = 0
+export function _sum<N extends number>(items: Iterable<N>): N {
+  let sum = 0 as N
   for (const n of items) {
-    sum += n
+    sum = (sum + n) as N
   }
   return sum
 }
 
-export function _sumBy<T>(items: Iterable<T>, mapper: Mapper<T, number | undefined>): number {
-  let sum = 0
+export function _sumBy<T, N extends number = number>(
+  items: Iterable<T>,
+  mapper: Mapper<T, N | undefined>,
+): N {
+  let sum = 0 as N
   let i = 0
 
   for (const n of items) {
     const v = mapper(n, i++)
     if (typeof v === 'number') {
       // count only numbers, nothing else
-      sum += v
+      sum = (sum + v) as N
     }
   }
 

--- a/src/array/array.util.ts
+++ b/src/array/array.util.ts
@@ -347,7 +347,7 @@ export function _difference<T>(a1: T[], a2: T[] | Set<T>): T[] {
 /**
  * Returns the sum of items, or 0 for empty array.
  */
-export function _sum<N extends number = number>(items: Iterable<N>): N {
+export function _sum<N extends number>(items: Iterable<N>): N {
   let sum = 0 as N
   for (const n of items) {
     sum = (sum + n) as N
@@ -355,7 +355,7 @@ export function _sum<N extends number = number>(items: Iterable<N>): N {
   return sum
 }
 
-export function _sumBy<T, N extends number = number>(
+export function _sumBy<T, N extends number>(
   items: Iterable<T>,
   mapper: Mapper<T, N | undefined>,
 ): N {

--- a/src/array/array.util.ts
+++ b/src/array/array.util.ts
@@ -347,7 +347,7 @@ export function _difference<T>(a1: T[], a2: T[] | Set<T>): T[] {
 /**
  * Returns the sum of items, or 0 for empty array.
  */
-export function _sum<N extends number>(items: Iterable<N>): N {
+export function _sum<N extends number = number>(items: Iterable<N>): N {
   let sum = 0 as N
   for (const n of items) {
     sum = (sum + n) as N


### PR DESCRIPTION
Suggestion to allow `_sum` and `_sumBy` to work with branded number types.

For example:
```ts
  type ExampleBrandedNumber = Branded<number, 'test'>
  const items: ExampleBrandedNumber[] = [1 as ExampleBrandedNumber, 2 as ExampleBrandedNumber]

  const sum: ExampleBrandedNumber = _sumBy(items, i => i) // as ExampleBrandedNumber
```

will not work without the commented casting.

Unfortunately this requires internal casting in the methods because the math binops don't support branded types either.

```ts
  const a = 1 as ExampleBrandedNumber
  const sum: ExampleBrandedNumber = a + a // <- type error Type 'number' is not assignable to type 'Branded<number, "test">'. Type 'number' is not assignable to type 'Brand<"test">'.ts(2322)
```

That fact makes me uncertain whether this is a bad idea for some reason, but I cannot think of one 🤔 

Besides that, I think this is a valid change because js-lib also defines the brand type helpers, and so can be expected to support branded types.