### PR TITLE
feat: generic cachekey function

### DIFF
--- a/src/decorators/asyncMemo.decorator.ts
+++ b/src/decorators/asyncMemo.decorator.ts
@@ -4,7 +4,7 @@ import { _objectAssign, AnyAsyncFunction, AnyFunction, AnyObject, MISS } from '.
 import { _getTargetMethodSignature } from './decorator.util'
 import { AsyncMemoCache, jsonMemoSerializer } from './memo.util'
 
-export interface AsyncMemoOptions {
+export interface AsyncMemoOptions<T extends AnyAsyncFunction> {
   /**
    * Provide a custom implementation of AsyncMemoCache.
    * Function that creates an instance of `AsyncMemoCache`.
@@ -14,7 +14,7 @@ export interface AsyncMemoOptions {
   /**
    * Provide a custom implementation of CacheKey function.
    */
-  cacheKeyFn?: (args: any[]) => any
+  cacheKeyFn?: (args: Parameters<T>) => any
 
   /**
    * Default to `console`
@@ -43,7 +43,7 @@ export interface AsyncMemoInstance {
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const _AsyncMemo =
-  (opt: AsyncMemoOptions): MethodDecorator =>
+  <T extends AnyAsyncFunction>(opt: AsyncMemoOptions<T>): MethodDecorator =>
   (target, key, descriptor) => {
     if (typeof descriptor.value !== 'function') {
       throw new TypeError('Memoization can be applied only to methods')
@@ -66,7 +66,7 @@ export const _AsyncMemo =
     const methodSignature = _getTargetMethodSignature(target, keyStr)
 
     // eslint-disable-next-line @typescript-eslint/promise-function-async
-    descriptor.value = function (this: typeof target, ...args: any[]): Promise<any> {
+    descriptor.value = function (this: typeof target, ...args: Parameters<T>): Promise<any> {
       const ctx = this
       const cacheKey = cacheKeyFn(args)
 

--- a/src/decorators/memo.decorator.test.ts
+++ b/src/decorators/memo.decorator.test.ts
@@ -7,7 +7,7 @@ class A {
     console.log(`func ${n}`)
   }
 
-  @_Memo<(a1: number, a2: number) => number>()
+  @_Memo()
   a(a1: number, a2: number): number {
     const n = a1 * a2
     this.func(n)

--- a/src/decorators/memo.decorator.test.ts
+++ b/src/decorators/memo.decorator.test.ts
@@ -7,7 +7,7 @@ class A {
     console.log(`func ${n}`)
   }
 
-  @_Memo()
+  @_Memo<(a1: number, a2: number) => number>()
   a(a1: number, a2: number): number {
     const n = a1 * a2
     this.func(n)

--- a/src/decorators/memo.decorator.ts
+++ b/src/decorators/memo.decorator.ts
@@ -3,7 +3,7 @@ import type { CommonLogger } from '../log/commonLogger'
 import { _objectAssign, AnyFunction, AnyObject, MaybeParameters } from '../types'
 import { _getTargetMethodSignature } from './decorator.util'
 import type { MemoCache } from './memo.util'
-import { jsonMemoSerializer, MapMemoCache } from './memo.util'
+import { jsonMemoSerializer, MapMemoCache, MethodDecorator } from './memo.util'
 
 export interface MemoOptions<T> {
   /**
@@ -34,13 +34,6 @@ export interface MemoInstance {
 
   getCache: (instance: AnyFunction) => MemoCache | undefined
 }
-
-// We override MethodDecorator to make it generic
-type MethodDecorator<T> = (
-  target: AnyObject,
-  propertyKey: string | symbol,
-  descriptor: TypedPropertyDescriptor<T>,
-) => TypedPropertyDescriptor<T> | undefined
 
 /**
  * Memoizes the method of the class, so it caches the output and returns the cached version if the "key"
@@ -119,7 +112,7 @@ export const _Memo =
       return value
     } as any
 
-    _objectAssign<MemoInstance>(descriptor.value as any, {
+    _objectAssign(descriptor.value as MemoInstance, {
       clear: () => {
         logger.log(`${methodSignature} @_Memo.clear()`)
         instanceCache.forEach(memoCache => memoCache.clear())

--- a/src/decorators/memo.decorator.ts
+++ b/src/decorators/memo.decorator.ts
@@ -5,7 +5,7 @@ import { _getTargetMethodSignature } from './decorator.util'
 import type { MemoCache } from './memo.util'
 import { jsonMemoSerializer, MapMemoCache } from './memo.util'
 
-export interface MemoOptions {
+export interface MemoOptions<T extends AnyFunction> {
   /**
    * Provide a custom implementation of MemoCache.
    * Function that creates an instance of `MemoCache`.
@@ -16,7 +16,7 @@ export interface MemoOptions {
   /**
    * Provide a custom implementation of CacheKey function.
    */
-  cacheKeyFn?: (args: any[]) => any
+  cacheKeyFn?: (args: Parameters<T>) => any
 
   /**
    * Default to `console`
@@ -57,7 +57,7 @@ export interface MemoInstance {
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const _Memo =
-  (opt: MemoOptions = {}): MethodDecorator =>
+  <T extends AnyFunction>(opt: MemoOptions<T> = {}): MethodDecorator =>
   (target, key, descriptor) => {
     if (typeof descriptor.value !== 'function') {
       throw new TypeError('Memoization can be applied only to methods')
@@ -83,7 +83,7 @@ export const _Memo =
     const keyStr = String(key)
     const methodSignature = _getTargetMethodSignature(target, keyStr)
 
-    descriptor.value = function (this: typeof target, ...args: any[]): any {
+    descriptor.value = function (this: typeof target, ...args: Parameters<T>): any {
       const ctx = this
       const cacheKey = cacheKeyFn(args)
 

--- a/src/decorators/memo.decorator.ts
+++ b/src/decorators/memo.decorator.ts
@@ -1,11 +1,11 @@
-import { _assert } from '../error/assert'
+import { _assert, _assertTypeOf } from '../error/assert'
 import type { CommonLogger } from '../log/commonLogger'
-import { _objectAssign, AnyFunction, AnyObject } from '../types'
+import { _objectAssign, AnyFunction, AnyObject, MaybeParameters } from '../types'
 import { _getTargetMethodSignature } from './decorator.util'
 import type { MemoCache } from './memo.util'
 import { jsonMemoSerializer, MapMemoCache } from './memo.util'
 
-export interface MemoOptions<T extends AnyFunction> {
+export interface MemoOptions<T> {
   /**
    * Provide a custom implementation of MemoCache.
    * Function that creates an instance of `MemoCache`.
@@ -16,7 +16,7 @@ export interface MemoOptions<T extends AnyFunction> {
   /**
    * Provide a custom implementation of CacheKey function.
    */
-  cacheKeyFn?: (args: Parameters<T>) => any
+  cacheKeyFn?: (args: MaybeParameters<T>) => any
 
   /**
    * Default to `console`
@@ -34,6 +34,13 @@ export interface MemoInstance {
 
   getCache: (instance: AnyFunction) => MemoCache | undefined
 }
+
+// We override MethodDecorator to make it generic
+type MethodDecorator<T> = (
+  target: AnyObject,
+  propertyKey: string | symbol,
+  descriptor: TypedPropertyDescriptor<T>,
+) => TypedPropertyDescriptor<T> | undefined
 
 /**
  * Memoizes the method of the class, so it caches the output and returns the cached version if the "key"
@@ -57,11 +64,13 @@ export interface MemoInstance {
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export const _Memo =
-  <T extends AnyFunction>(opt: MemoOptions<T> = {}): MethodDecorator =>
+  <T>(opt: MemoOptions<T> = {}): MethodDecorator<T> =>
   (target, key, descriptor) => {
-    if (typeof descriptor.value !== 'function') {
-      throw new TypeError('Memoization can be applied only to methods')
-    }
+    _assertTypeOf<AnyFunction>(
+      descriptor.value,
+      'function',
+      'Memoization can be applied only to methods',
+    )
 
     const originalFn = descriptor.value
 
@@ -83,7 +92,7 @@ export const _Memo =
     const keyStr = String(key)
     const methodSignature = _getTargetMethodSignature(target, keyStr)
 
-    descriptor.value = function (this: typeof target, ...args: Parameters<T>): any {
+    descriptor.value = function (this: typeof target, ...args: MaybeParameters<T>): any {
       const ctx = this
       const cacheKey = cacheKeyFn(args)
 
@@ -110,7 +119,7 @@ export const _Memo =
       return value
     } as any
 
-    _objectAssign(descriptor.value as MemoInstance, {
+    _objectAssign<MemoInstance>(descriptor.value as any, {
       clear: () => {
         logger.log(`${methodSignature} @_Memo.clear()`)
         instanceCache.forEach(memoCache => memoCache.clear())

--- a/src/decorators/memo.util.ts
+++ b/src/decorators/memo.util.ts
@@ -1,6 +1,6 @@
 import { _isPrimitive } from '../is.util'
 import { pDelay } from '../promise/pDelay'
-import type { UnixTimestamp } from '../types'
+import type { AnyObject, UnixTimestamp } from '../types'
 import { MISS } from '../types'
 
 export type MemoSerializer = (args: any[]) => any
@@ -147,3 +147,14 @@ export class MapAsyncMemoCache<KEY = any, VALUE = any> implements AsyncMemoCache
     this.m.clear()
   }
 }
+
+/**
+ * Generic override of Typescript's built in legacy MethodDecorator, that
+ * allows us to infer the parameters of the decorated method from the parameters
+ * of a decorator.
+ */
+export type MethodDecorator<T> = (
+  target: AnyObject,
+  propertyKey: string | symbol,
+  descriptor: TypedPropertyDescriptor<T>,
+) => TypedPropertyDescriptor<T> | undefined

--- a/src/decorators/memoFn.ts
+++ b/src/decorators/memoFn.ts
@@ -1,3 +1,4 @@
+import { AnyFunction } from '../types'
 import type { MemoOptions } from './memo.decorator'
 import type { MemoCache } from './memo.util'
 import { jsonMemoSerializer, MapMemoCache } from './memo.util'
@@ -13,9 +14,9 @@ export interface MemoizedFunction {
  *
  * @experimental
  */
-export function _memoFn<T extends (...args: any[]) => any>(
+export function _memoFn<T extends AnyFunction>(
   fn: T,
-  opt: MemoOptions = {},
+  opt: MemoOptions<T> = {},
 ): T & MemoizedFunction {
   const {
     logger = console,
@@ -25,7 +26,7 @@ export function _memoFn<T extends (...args: any[]) => any>(
 
   const cache = cacheFactory()
 
-  const memoizedFn = function (this: any, ...args: any[]): T {
+  const memoizedFn = function (this: any, ...args: Parameters<T>): T {
     const ctx = this
     const cacheKey = cacheKeyFn(args)
 

--- a/src/decorators/memoFn.ts
+++ b/src/decorators/memoFn.ts
@@ -1,4 +1,4 @@
-import { AnyFunction } from '../types'
+import { AnyFunction, MaybeParameters } from '../types'
 import type { MemoOptions } from './memo.decorator'
 import type { MemoCache } from './memo.util'
 import { jsonMemoSerializer, MapMemoCache } from './memo.util'
@@ -26,7 +26,7 @@ export function _memoFn<T extends AnyFunction>(
 
   const cache = cacheFactory()
 
-  const memoizedFn = function (this: any, ...args: Parameters<T>): T {
+  const memoizedFn = function (this: any, ...args: MaybeParameters<T>): T {
     const ctx = this
     const cacheKey = cacheKeyFn(args)
 

--- a/src/decorators/memoFnAsync.ts
+++ b/src/decorators/memoFnAsync.ts
@@ -1,4 +1,4 @@
-import { AnyAsyncFunction, MISS } from '../types'
+import { AnyAsyncFunction, MaybeParameters, MISS } from '../types'
 import type { AsyncMemoOptions } from './asyncMemo.decorator'
 import type { AsyncMemoCache } from './memo.util'
 import { jsonMemoSerializer, MapMemoCache } from './memo.util'
@@ -22,7 +22,7 @@ export function _memoFnAsync<T extends AnyAsyncFunction>(
 
   const cache = cacheFactory()
 
-  const memoizedFn = async function (this: any, ...args: Parameters<T>): Promise<any> {
+  const memoizedFn = async function (this: any, ...args: MaybeParameters<T>): Promise<any> {
     const ctx = this
     const cacheKey = cacheKeyFn(args)
     let value: any

--- a/src/decorators/memoFnAsync.ts
+++ b/src/decorators/memoFnAsync.ts
@@ -1,4 +1,4 @@
-import { MISS } from '../types'
+import { AnyAsyncFunction, MISS } from '../types'
 import type { AsyncMemoOptions } from './asyncMemo.decorator'
 import type { AsyncMemoCache } from './memo.util'
 import { jsonMemoSerializer, MapMemoCache } from './memo.util'
@@ -10,9 +10,9 @@ export interface MemoizedAsyncFunction {
 /**
  * @experimental
  */
-export function _memoFnAsync<T extends (...args: any[]) => Promise<any>>(
+export function _memoFnAsync<T extends AnyAsyncFunction>(
   fn: T,
-  opt: AsyncMemoOptions,
+  opt: AsyncMemoOptions<T>,
 ): T & MemoizedAsyncFunction {
   const {
     logger = console,
@@ -22,7 +22,7 @@ export function _memoFnAsync<T extends (...args: any[]) => Promise<any>>(
 
   const cache = cacheFactory()
 
-  const memoizedFn = async function (this: any, ...args: any[]): Promise<any> {
+  const memoizedFn = async function (this: any, ...args: Parameters<T>): Promise<any> {
     const ctx = this
     const cacheKey = cacheKeyFn(args)
     let value: any

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,10 @@ export type LazyPromise<T> = () => Promise<T>
  * A function that lazily calculates something async, that can return null.
  */
 export type LazyNullablePromise<T> = () => Promise<T | null>
+/**
+ * Evaluates to the parameters if T is a function, otherwise never
+ */
+export type MaybeParameters<T> = T extends AnyFunction ? Parameters<T> : never
 
 /**
  * Symbol to indicate END of Sequence.


### PR DESCRIPTION
I can see this not being nice enough, but it's a thought. Stop me if I'm being too generic in this repo 😅 

<img src="https://github.com/user-attachments/assets/a6eab1d2-6f26-4816-9dfe-796961cab07c" width=300 />

This PR overrides a TS type. Is it a better type? Maybe. Typescript maintainers don't agree (when the idea is badly motivated): https://github.com/microsoft/TypeScript/issues/55980

(edited to reflect #31 being merged into this)