### PR TITLE
chore: allow auto-compress on document DBs only

### DIFF
--- a/packages/db-lib/src/commondao/common.dao.test.ts
+++ b/packages/db-lib/src/commondao/common.dao.test.ts
@@ -5,6 +5,7 @@ import { _deepFreeze, _omit } from '@naturalcycles/js-lib/object'
 import type { BaseDBEntity, UnixTimestamp, Unsaved } from '@naturalcycles/js-lib/types'
 import { AjvValidationError } from '@naturalcycles/nodejs-lib/ajv'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { CommonDBType } from '../commondb/common.db.js'
 import { InMemoryDB } from '../inmemory/inMemory.db.js'
 import type { TestItemBM, TestItemDBM } from '../testing/index.js'
 import {
@@ -1272,5 +1273,34 @@ describe('auto compression', () => {
     )
 
     saveBatchSpy.mockRestore()
+  })
+
+  test('should throw when used with a relational DB', () => {
+    const relationalDB = new InMemoryDB()
+    ;(relationalDB as any).dbType = CommonDBType.relational
+
+    expect(
+      () =>
+        new CommonDao<Item>({
+          table: TEST_TABLE,
+          db: relationalDB,
+          compress: {
+            keys: ['obj', 'shu'],
+          },
+        }),
+    ).toThrow(/compress feature is only supported on document DBs/)
+  })
+
+  test('should not throw when used with a document DB', () => {
+    expect(
+      () =>
+        new CommonDao<Item>({
+          table: TEST_TABLE,
+          db,
+          compress: {
+            keys: ['obj', 'shu'],
+          },
+        }),
+    ).not.toThrow()
   })
 })

--- a/packages/db-lib/src/commondao/common.dao.ts
+++ b/packages/db-lib/src/commondao/common.dao.ts
@@ -29,6 +29,7 @@ import type { JsonSchema } from '@naturalcycles/nodejs-lib/ajv'
 import type { Pipeline } from '@naturalcycles/nodejs-lib/stream'
 import { zip2 } from '@naturalcycles/nodejs-lib/zip'
 import { DBLibError } from '../cnst.js'
+import { CommonDBType } from '../commondb/common.db.js'
 import type {
   CommonDBSaveOptions,
   CommonDBTransactionOptions,
@@ -94,6 +95,15 @@ export class CommonDao<
     // If the auto-compression is enabled,
     // then we need to ensure that the '__compressed' property is part of the index exclusion list.
     if (this.cfg.compress?.keys) {
+      // Auto-compression stores a Buffer in a dedicated `__compressed` property and relies on
+      // `excludeFromIndexes`, both of which are Datastore-specific. Using it with a relational DB
+      // (e.g. MySQL) would require an explicit column/schema and would silently ignore
+      // `excludeFromIndexes` — so we block it at construction time.
+      _assert(
+        this.cfg.db.dbType === CommonDBType.document,
+        `CommonDao "${this.cfg.table}": compress feature is only supported on document DBs (e.g. Datastore), got dbType=${this.cfg.db.dbType}`,
+      )
+
       const current = this.cfg.excludeFromIndexes
       this.cfg.excludeFromIndexes = current ? [...current] : []
       if (!this.cfg.excludeFromIndexes.includes('__compressed' as any)) {


### PR DESCRIPTION
In this PR, I set a check that we use `compress` only in non-relation DBs.

I started thinking about ChunkedDao, and I realized we'd need this check.
Then I realized we may not have it for `compress`.
And we don't.

Is this approach good enough?