### PR TITLE
feat: add automatic chunking

### DIFF
--- a/packages/db-lib/src/commondao/common.dao.model.ts
+++ b/packages/db-lib/src/commondao/common.dao.model.ts
@@ -224,6 +224,22 @@ export interface CommonDaoCfg<
      * Undefined will default to level 1 (not the 3, which is the zstd default)
      */
     level?: Integer
+    /**
+     * When truthy, if the compressed payload exceeds `maxChunkSize` the entity is
+     * transparently split into multiple storage rows.
+     *
+     * Layout:
+     * - Primary row at `id`: queryable fields + `__compressed: <chunk0>` + `__chunks: N` (when N > 1)
+     * - Extra chunk rows at `${id}__c${n}` (n=1..N-1): `{ id, __chunked: true, __compressed: <chunkN> }`
+     *
+     * Requires `keys` to be non-empty (chunking only splits the `__compressed` Buffer).
+     * Only supported on document DBs (e.g. Datastore) — same constraint as `compress`.
+     *
+     * User-facing entity ids MUST NOT match `/__c\d+$/` when chunking is enabled.
+     *
+     * @experimental
+     */
+    chunk?: boolean | { maxChunkSize?: Integer }
   }
 }
 

--- a/packages/db-lib/src/commondao/common.dao.model.ts
+++ b/packages/db-lib/src/commondao/common.dao.model.ts
@@ -226,16 +226,37 @@ export interface CommonDaoCfg<
     level?: Integer
     /**
      * When truthy, if the compressed payload exceeds `maxChunkSize` the entity is
-     * transparently split into multiple storage rows.
+     * transparently split across a primary row and a dedicated chunks kind.
      *
      * Layout:
-     * - Primary row at `id`: queryable fields + `__compressed: <chunk0>` + `__chunks: N` (when N > 1)
-     * - Extra chunk rows at `${id}__c${n}` (n=1..N-1): `{ id, __chunked: true, __compressed: <chunkN> }`
+     * - Primary row in `${table}`: queryable fields + `__compressed: <chunk0>` + `__chunks: N` (when N > 1)
+     * - Extra chunk rows in `${table}__chunks`: `{ id, primaryId, chunkIdx, __compressed }`
      *
      * Requires `keys` to be non-empty (chunking only splits the `__compressed` Buffer).
      * Only supported on document DBs (e.g. Datastore) — same constraint as `compress`.
      *
-     * User-facing entity ids MUST NOT match `/__c\d+$/` when chunking is enabled.
+     * ## Caveats
+     *
+     * **Naming collision**: the library reserves `${table}__chunks` as the chunks kind. Do not
+     * use a primary `table` name ending in `__chunks` when chunking is enabled, or it will
+     * collide with another DAO's chunks kind.
+     *
+     * **Transactions**: Datastore's `DBTransaction` only supports key-based ops, but chunks
+     * use queries (`runQuery` / `deleteByQuery`). Chunks operations therefore always run
+     * outside the caller's transaction. Consequences:
+     * - If a transaction wrapping `dao.save(chunkedEntity)` rolls back, the primary rolls back
+     *   but new chunks persist as orphans (harmless — ignored by reads, cleaned up by the
+     *   next successful save of the same id).
+     * - If the chunks-write fails after the primary has committed, reads will throw
+     *   "missing chunk" until the next successful save.
+     *
+     * These are accepted trade-offs for simplicity. Do not enable `chunk` for tables where
+     * strict transactional consistency on large-payload writes is required.
+     *
+     * **Orphan cleanup cost**: every save of a chunked entity issues up to
+     * `MAX_CHUNKS_PER_ENTITY - 1` no-op delete ops to clean up potential stale chunks. This is
+     * safe and idempotent but consumes delete quota. See `cleanupOrphanChunksForMany` for a
+     * showcase alternative using a composite index.
      *
      * @experimental
      */

--- a/packages/db-lib/src/commondao/common.dao.test.ts
+++ b/packages/db-lib/src/commondao/common.dao.test.ts
@@ -1320,20 +1320,27 @@ describe('auto chunking', () => {
     })
   })
 
-  test('round-trip large entity splits into N storage rows', async () => {
+  test('round-trip large entity splits into primary + chunks across two tables', async () => {
     const { dao, db: localDb } = newDao()
     const obj = makeLargeObj(SMALL_MAX * 4) // forces multiple chunks
     await dao.save({ id: 'big', obj })
 
-    const storage = localDb.data[TEST_TABLE]!
-    const ids = Object.keys(storage).sort()
-    expect(ids.length).toBeGreaterThan(1)
-    expect(ids[0]).toBe('big')
-    expect((storage['big'] as any).__chunks).toBeGreaterThanOrEqual(2)
-    // All overflow rows have __chunked: true and match the id pattern
-    for (const id of ids.slice(1)) {
+    const primaryTable = localDb.data[TEST_TABLE]!
+    const chunksTable = localDb.data[`${TEST_TABLE}__chunks`]!
+    // Primary table has just the primary
+    expect(Object.keys(primaryTable)).toEqual(['big'])
+    const n = (primaryTable['big'] as any).__chunks as number
+    expect(n).toBeGreaterThanOrEqual(2)
+
+    // Chunks table has n-1 extra chunk rows with primaryId and chunkIdx
+    const chunkIds = Object.keys(chunksTable).sort()
+    expect(chunkIds).toHaveLength(n - 1)
+    for (const id of chunkIds) {
       expect(id).toMatch(/^big__c\d+$/)
-      expect((storage[id] as any).__chunked).toBe(true)
+      const cr = chunksTable[id] as any
+      expect(cr.primaryId).toBe('big')
+      expect(typeof cr.chunkIdx).toBe('number')
+      expect(Buffer.isBuffer(cr.__compressed)).toBe(true)
     }
 
     const back = await dao.getById('big')
@@ -1347,11 +1354,12 @@ describe('auto chunking', () => {
     const initialN = (localDb.data[TEST_TABLE]!['e1'] as any).__chunks as number
     expect(initialN).toBeGreaterThanOrEqual(3)
 
-    // Re-save with much smaller payload — should now fit in 1 row, old chunks should be gone
+    // Re-save with much smaller payload — should now fit in 1 row, all chunks should be gone
     await dao.save({ id: 'e1', obj: { n: 1 } })
-    const ids = Object.keys(localDb.data[TEST_TABLE]!).sort()
-    expect(ids).toEqual(['e1'])
+    expect(Object.keys(localDb.data[TEST_TABLE]!)).toEqual(['e1'])
     expect((localDb.data[TEST_TABLE]!['e1'] as any).__chunks).toBeUndefined()
+    const chunksTable = localDb.data[`${TEST_TABLE}__chunks`] ?? {}
+    expect(Object.keys(chunksTable)).toEqual([])
   })
 
   test('orphan cleanup: N→M shrink where M > 1 deletes only stale chunks', async () => {
@@ -1368,55 +1376,25 @@ describe('auto chunking', () => {
     expect(newN).toBeGreaterThanOrEqual(2)
     expect(newN).toBeLessThan(initialN)
 
-    // Only primary + newN-1 chunk rows remain; old chunks beyond newN are gone
-    const ids = Object.keys(localDb.data[TEST_TABLE]!).sort()
-    expect(ids).toHaveLength(newN) // primary + (newN - 1) chunks
-    expect(ids[0]).toBe('e2')
+    // Primary table has just the primary; chunks table has exactly newN-1 rows
+    expect(Object.keys(localDb.data[TEST_TABLE]!)).toEqual(['e2'])
+    const chunksTable = localDb.data[`${TEST_TABLE}__chunks`]!
+    expect(Object.keys(chunksTable)).toHaveLength(newN - 1)
 
     // Round-trip still works
     const back = await dao.getById('e2')
     expect(back?.obj).toEqual(medBig)
   })
 
-  test('orphan cleanup uses PREV_CHUNKS symbol for exact range', async () => {
-    const { dao, db: localDb } = newDao()
-    const big = makeLargeObj(SMALL_MAX * 5)
-    await dao.save({ id: 'sym', obj: big })
-    const initialN = (localDb.data[TEST_TABLE]!['sym'] as any).__chunks as number
-    expect(initialN).toBeGreaterThanOrEqual(3)
-
-    // Read the entity — this stamps PREV_CHUNKS on the returned object
-    const loaded = await dao.getById('sym')
-    expect(loaded).toBeTruthy()
-
-    // Spy on deleteByIds to verify exact orphan range
-    const deleteSpy = vi.spyOn(localDb, 'deleteByIds')
-
-    // Re-save with a small payload (1 chunk) — orphan cleanup should target exactly
-    // indices initialN..initialN-1, not 1..99
-    loaded!.obj = { n: 1 }
-    await dao.save(loaded!)
-
-    // The deleteByIds call for orphans should contain at most initialN - 1 ids (indices 1..initialN-1),
-    // NOT 99 ids (indices 1..99)
-    const orphanDeleteCall = deleteSpy.mock.calls.find(call =>
-      call[1].some(id => id.startsWith('sym__c')),
-    )
-    expect(orphanDeleteCall).toBeDefined()
-    const deletedChunkIds = orphanDeleteCall![1].filter(id => id.startsWith('sym__c'))
-    expect(deletedChunkIds).toHaveLength(initialN - 1)
-
-    deleteSpy.mockRestore()
-  })
-
   test('deleteById removes all chunk rows', async () => {
     const { dao, db: localDb } = newDao()
     await dao.save({ id: 'del', obj: makeLargeObj(SMALL_MAX * 4) })
-    const ids = Object.keys(localDb.data[TEST_TABLE]!)
-    expect(ids.length).toBeGreaterThan(1)
+    const chunksTable = localDb.data[`${TEST_TABLE}__chunks`]!
+    expect(Object.keys(chunksTable).length).toBeGreaterThan(0)
 
     await dao.deleteById('del')
     expect(Object.keys(localDb.data[TEST_TABLE]!)).toEqual([])
+    expect(Object.keys(localDb.data[`${TEST_TABLE}__chunks`] ?? {})).toEqual([])
   })
 
   test('runQuery filters out chunk rows', async () => {
@@ -1483,10 +1461,9 @@ describe('auto chunking', () => {
 
     const back = await dao.getById('p1')
     expect(back?.obj).toEqual({ ...initial, extra: 'x' })
-    // Storage should still have primary + chunks
-    const ids = Object.keys(localDb.data[TEST_TABLE]!)
-    expect(ids.length).toBeGreaterThan(1)
-    expect(ids).toContain('p1')
+    // Primary exists; chunks table has chunk rows
+    expect(Object.keys(localDb.data[TEST_TABLE]!)).toContain('p1')
+    expect(Object.keys(localDb.data[`${TEST_TABLE}__chunks`] ?? {}).length).toBeGreaterThan(0)
   })
 
   test('patchByQuery throws when chunking enabled', async () => {
@@ -1503,33 +1480,28 @@ describe('auto chunking', () => {
     )
   })
 
-  test('runQueryCount throws on unfiltered query when chunking enabled', async () => {
+  test('runQueryCount is accurate regardless of filter (chunks live in a separate table)', async () => {
     const { dao } = newDao()
-    await expect(dao.query().runQueryCount()).rejects.toThrow(/requires at least one filter/)
-  })
-
-  test('runQueryCount works with a filter', async () => {
-    const { dao } = newDao()
-    await dao.save({ id: 'c1', obj: { n: 1 } })
+    await dao.save({ id: 'c1', obj: makeLargeObj(SMALL_MAX * 3) })
     await dao.save({ id: 'c2', obj: { n: 2 } })
 
-    const count = await dao.query().filterEq('id', 'c1').runQueryCount()
-    expect(count).toBe(1)
+    // Unfiltered count is correct now — chunks are in `${table}__chunks`, not this table.
+    expect(await dao.query().runQueryCount()).toBe(2)
+    expect(await dao.query().filterEq('id', 'c1').runQueryCount()).toBe(1)
   })
 
-  test('entity id matching chunk pattern is rejected even for small entities', async () => {
-    const { dao } = newDao()
-    // Small entity that doesn't need chunking — but the id matches the reserved pattern
-    await expect(dao.save({ id: 'bad__c1', obj: { n: 1 } })).rejects.toThrow(
-      /reserved chunk-id pattern/,
-    )
-    // Large entity that does need chunking
-    await expect(dao.save({ id: 'bad__c1', obj: makeLargeObj(SMALL_MAX * 3) })).rejects.toThrow(
-      /reserved chunk-id pattern/,
-    )
-  })
+  test(
+    String.raw`entity ids can freely match /__c\d+$/ — no collision with chunks table`,
+    async () => {
+      const { dao } = newDao()
+      // This used to be forbidden when chunks lived in the same table; now it's fine.
+      await dao.save({ id: 'item__c1', obj: { n: 1 } })
+      const back = await dao.getById('item__c1')
+      expect(back?.obj).toEqual({ n: 1 })
+    },
+  )
 
-  test('auto-adds __chunked and __chunks to excludeFromIndexes', async () => {
+  test('auto-adds __compressed and __chunks to excludeFromIndexes on primary', async () => {
     const { dao, db: localDb } = newDao()
     const saveBatchSpy = vi.spyOn(localDb, 'saveBatch')
 
@@ -1539,13 +1511,13 @@ describe('auto chunking', () => {
       TEST_TABLE,
       expect.any(Array),
       expect.objectContaining({
-        excludeFromIndexes: expect.arrayContaining(['__compressed', '__chunked', '__chunks']),
+        excludeFromIndexes: expect.arrayContaining(['__compressed', '__chunks']),
       }),
     )
     saveBatchSpy.mockRestore()
   })
 
-  test('deleteByQuery removes chunk rows', async () => {
+  test('deleteByQuery removes primaries and their chunks', async () => {
     const { dao, db: localDb } = newDao()
     await dao.save({ id: 'dq1', obj: makeLargeObj(SMALL_MAX * 3) })
     await dao.save({ id: 'dq2', obj: { n: 1 } })
@@ -1553,6 +1525,7 @@ describe('auto chunking', () => {
     const deleted = await dao.deleteByQuery(dao.query())
     expect(deleted).toBe(2)
     expect(Object.keys(localDb.data[TEST_TABLE] || {})).toEqual([])
+    expect(Object.keys(localDb.data[`${TEST_TABLE}__chunks`] ?? {})).toEqual([])
   })
 
   test('saveBatch with mix of chunked and non-chunked entities', async () => {
@@ -1571,8 +1544,9 @@ describe('auto chunking', () => {
     expect(byId['b3']!.obj).toEqual(big)
     expect(byId['b2']!.obj).toEqual({ n: 1 })
 
-    // Storage should have at least 5 rows (3 primaries + chunks for 2 big ones)
-    expect(Object.keys(localDb.data[TEST_TABLE]!).length).toBeGreaterThanOrEqual(5)
+    // Primary table has exactly 3 primaries; chunks table has chunks for b1 + b3
+    expect(Object.keys(localDb.data[TEST_TABLE]!).sort()).toEqual(['b1', 'b2', 'b3'])
+    expect(Object.keys(localDb.data[`${TEST_TABLE}__chunks`] ?? {}).length).toBeGreaterThan(0)
   })
 
   test('constructor rejects chunk without keys', () => {

--- a/packages/db-lib/src/commondao/common.dao.test.ts
+++ b/packages/db-lib/src/commondao/common.dao.test.ts
@@ -1386,6 +1386,50 @@ describe('auto chunking', () => {
     expect(back?.obj).toEqual(medBig)
   })
 
+  test('orphan cleanup deletes exact range (count-first, no 99-id amplification)', async () => {
+    const { dao, db: localDb } = newDao()
+    const big = makeLargeObj(SMALL_MAX * 5)
+    await dao.save({ id: 'exact', obj: big })
+    const initialN = (localDb.data[TEST_TABLE]!['exact'] as any).__chunks as number
+    expect(initialN).toBeGreaterThanOrEqual(3)
+
+    // Spy on deleteByIds targeting the chunks table
+    const deleteSpy = vi.spyOn(localDb, 'deleteByIds')
+
+    // Shrink to a single row
+    await dao.save({ id: 'exact', obj: { n: 1 } })
+
+    // Orphan delete call(s) on the chunks table should contain exactly initialN - 1 ids,
+    // NOT the full MAX_CHUNKS_PER_ENTITY - 1 (99) candidate range.
+    const chunksDeleteCalls = deleteSpy.mock.calls.filter(
+      call => call[0] === `${TEST_TABLE}__chunks`,
+    )
+    const totalChunkIdsDeleted = chunksDeleteCalls.reduce((sum, call) => sum + call[1].length, 0)
+    expect(totalChunkIdsDeleted).toBe(initialN - 1)
+
+    deleteSpy.mockRestore()
+  })
+
+  test('orphan cleanup: no orphans → no delete call issued', async () => {
+    const { dao, db: localDb } = newDao()
+    // Save a chunked entity, then immediately re-save at the SAME chunk count
+    const big = makeLargeObj(SMALL_MAX * 3)
+    await dao.save({ id: 'same', obj: big })
+
+    const deleteSpy = vi.spyOn(localDb, 'deleteByIds')
+
+    // Re-save with equivalent payload (same approximate size → same N)
+    await dao.save({ id: 'same', obj: big })
+
+    // No orphan deletes should fire against the chunks table
+    const chunksDeleteCalls = deleteSpy.mock.calls.filter(
+      call => call[0] === `${TEST_TABLE}__chunks`,
+    )
+    expect(chunksDeleteCalls).toEqual([])
+
+    deleteSpy.mockRestore()
+  })
+
   test('deleteById removes all chunk rows', async () => {
     const { dao, db: localDb } = newDao()
     await dao.save({ id: 'del', obj: makeLargeObj(SMALL_MAX * 4) })

--- a/packages/db-lib/src/commondao/common.dao.test.ts
+++ b/packages/db-lib/src/commondao/common.dao.test.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto'
 import { MOCK_TS_2018_06_21 } from '@naturalcycles/dev-lib/testing/time'
 import { _range, _sortBy } from '@naturalcycles/js-lib/array'
 import { ErrorMode, pExpectedError, pExpectedErrorString, pTry } from '@naturalcycles/js-lib/error'
@@ -1272,5 +1273,316 @@ describe('auto compression', () => {
     )
 
     saveBatchSpy.mockRestore()
+  })
+})
+
+describe('auto chunking', () => {
+  // Small threshold so tests can trigger chunking with reasonable payload sizes.
+  const SMALL_MAX = 128
+
+  // Build a payload that compresses to more than N bytes. Uses random base64 so content
+  // is incompressible; compressed length ≳ uncompressed length.
+  function makeLargeObj(approxUncompressedBytes: number): any {
+    const buf = randomBytes(approxUncompressedBytes)
+    return { blob: buf.toString('base64') }
+  }
+
+  function newDao(chunkCfg: boolean | { maxChunkSize?: number } = { maxChunkSize: SMALL_MAX }): {
+    dao: CommonDao<Item>
+    db: InMemoryDB
+  } {
+    const localDb = new InMemoryDB()
+    const dao = new CommonDao<Item>({
+      table: TEST_TABLE,
+      db: localDb,
+      compress: {
+        keys: ['obj'],
+        chunk: chunkCfg,
+      },
+    })
+    return { dao, db: localDb }
+  }
+
+  test('round-trip small entity saves as a single row', async () => {
+    const { dao, db: localDb } = newDao()
+    await dao.save({ id: 'abc', obj: { n: 1 } })
+
+    const storage = localDb.data[TEST_TABLE]!
+    expect(Object.keys(storage)).toEqual(['abc'])
+    expect((storage['abc'] as any).__chunks).toBeUndefined()
+
+    const back = await dao.getById('abc')
+    expect(back).toEqual({
+      id: 'abc',
+      obj: { n: 1 },
+      created: expect.any(Number),
+      updated: expect.any(Number),
+    })
+  })
+
+  test('round-trip large entity splits into N storage rows', async () => {
+    const { dao, db: localDb } = newDao()
+    const obj = makeLargeObj(SMALL_MAX * 4) // forces multiple chunks
+    await dao.save({ id: 'big', obj })
+
+    const storage = localDb.data[TEST_TABLE]!
+    const ids = Object.keys(storage).sort()
+    expect(ids.length).toBeGreaterThan(1)
+    expect(ids[0]).toBe('big')
+    expect((storage['big'] as any).__chunks).toBeGreaterThanOrEqual(2)
+    // All overflow rows have __chunked: true and match the id pattern
+    for (const id of ids.slice(1)) {
+      expect(id).toMatch(/^big__c\d+$/)
+      expect((storage[id] as any).__chunked).toBe(true)
+    }
+
+    const back = await dao.getById('big')
+    expect(back?.obj).toEqual(obj)
+  })
+
+  test('orphan cleanup: shrinking chunk count deletes stale chunks', async () => {
+    const { dao, db: localDb } = newDao()
+    const big = makeLargeObj(SMALL_MAX * 5)
+    await dao.save({ id: 'e1', obj: big })
+    const initialN = (localDb.data[TEST_TABLE]!['e1'] as any).__chunks as number
+    expect(initialN).toBeGreaterThanOrEqual(3)
+
+    // Re-save with much smaller payload — should now fit in 1 row, old chunks should be gone
+    await dao.save({ id: 'e1', obj: { n: 1 } })
+    const ids = Object.keys(localDb.data[TEST_TABLE]!).sort()
+    expect(ids).toEqual(['e1'])
+    expect((localDb.data[TEST_TABLE]!['e1'] as any).__chunks).toBeUndefined()
+  })
+
+  test('orphan cleanup: N→M shrink where M > 1 deletes only stale chunks', async () => {
+    const { dao, db: localDb } = newDao()
+    const veryBig = makeLargeObj(SMALL_MAX * 6)
+    await dao.save({ id: 'e2', obj: veryBig })
+    const initialN = (localDb.data[TEST_TABLE]!['e2'] as any).__chunks as number
+    expect(initialN).toBeGreaterThanOrEqual(4)
+
+    // Re-save with a smaller-but-still-chunked payload
+    const medBig = makeLargeObj(SMALL_MAX * 3)
+    await dao.save({ id: 'e2', obj: medBig })
+    const newN = (localDb.data[TEST_TABLE]!['e2'] as any).__chunks as number
+    expect(newN).toBeGreaterThanOrEqual(2)
+    expect(newN).toBeLessThan(initialN)
+
+    // Only primary + newN-1 chunk rows remain; old chunks beyond newN are gone
+    const ids = Object.keys(localDb.data[TEST_TABLE]!).sort()
+    expect(ids).toHaveLength(newN) // primary + (newN - 1) chunks
+    expect(ids[0]).toBe('e2')
+
+    // Round-trip still works
+    const back = await dao.getById('e2')
+    expect(back?.obj).toEqual(medBig)
+  })
+
+  test('orphan cleanup uses PREV_CHUNKS symbol for exact range', async () => {
+    const { dao, db: localDb } = newDao()
+    const big = makeLargeObj(SMALL_MAX * 5)
+    await dao.save({ id: 'sym', obj: big })
+    const initialN = (localDb.data[TEST_TABLE]!['sym'] as any).__chunks as number
+    expect(initialN).toBeGreaterThanOrEqual(3)
+
+    // Read the entity — this stamps PREV_CHUNKS on the returned object
+    const loaded = await dao.getById('sym')
+    expect(loaded).toBeTruthy()
+
+    // Spy on deleteByIds to verify exact orphan range
+    const deleteSpy = vi.spyOn(localDb, 'deleteByIds')
+
+    // Re-save with a small payload (1 chunk) — orphan cleanup should target exactly
+    // indices initialN..initialN-1, not 1..99
+    loaded!.obj = { n: 1 }
+    await dao.save(loaded!)
+
+    // The deleteByIds call for orphans should contain at most initialN - 1 ids (indices 1..initialN-1),
+    // NOT 99 ids (indices 1..99)
+    const orphanDeleteCall = deleteSpy.mock.calls.find(call =>
+      call[1].some(id => id.startsWith('sym__c')),
+    )
+    expect(orphanDeleteCall).toBeDefined()
+    const deletedChunkIds = orphanDeleteCall![1].filter(id => id.startsWith('sym__c'))
+    expect(deletedChunkIds).toHaveLength(initialN - 1)
+
+    deleteSpy.mockRestore()
+  })
+
+  test('deleteById removes all chunk rows', async () => {
+    const { dao, db: localDb } = newDao()
+    await dao.save({ id: 'del', obj: makeLargeObj(SMALL_MAX * 4) })
+    const ids = Object.keys(localDb.data[TEST_TABLE]!)
+    expect(ids.length).toBeGreaterThan(1)
+
+    await dao.deleteById('del')
+    expect(Object.keys(localDb.data[TEST_TABLE]!)).toEqual([])
+  })
+
+  test('runQuery filters out chunk rows', async () => {
+    const { dao } = newDao()
+    await dao.save({ id: 'one', obj: makeLargeObj(SMALL_MAX * 3) })
+    await dao.save({ id: 'two', obj: { small: true } })
+
+    const all = await dao.getAll()
+    expect(all.map(r => r.id).sort()).toEqual(['one', 'two'])
+    // Reassembly restored the full obj
+    const byId = Object.fromEntries(all.map(r => [r.id, r]))
+    expect(byId['one']!.obj).toEqual(expect.objectContaining({ blob: expect.any(String) }))
+  })
+
+  test('streamQuery filters and reassembles', async () => {
+    const { dao } = newDao()
+    await dao.save({ id: 's1', obj: makeLargeObj(SMALL_MAX * 3) })
+    await dao.save({ id: 's2', obj: { small: true } })
+
+    const results = await dao.streamQuery(dao.query()).toArray()
+    expect(results.map(r => r.id).sort()).toEqual(['s1', 's2'])
+    const byId = Object.fromEntries(results.map(r => [r.id, r]))
+    expect(byId['s1']!.obj).toEqual(expect.objectContaining({ blob: expect.any(String) }))
+  })
+
+  test('partial query (select) still filters chunk rows', async () => {
+    const { dao } = newDao()
+    await dao.save({ id: 'p1', obj: makeLargeObj(SMALL_MAX * 3) })
+    await dao.save({ id: 'p2', obj: { n: 1 } })
+
+    const ids = await dao.queryIds(dao.query())
+    expect(ids.sort()).toEqual(['p1', 'p2'])
+  })
+
+  test('queryIds and streamQueryIds exclude chunk ids', async () => {
+    const { dao } = newDao()
+    await dao.save({ id: 'q1', obj: makeLargeObj(SMALL_MAX * 3) })
+
+    const ids = await dao.queryIds(dao.query())
+    expect(ids).toEqual(['q1'])
+
+    const streamedIds = await dao.streamQueryIds(dao.query()).toArray()
+    expect(streamedIds).toEqual(['q1'])
+  })
+
+  test('getByIds mixed chunked + non-chunked', async () => {
+    const { dao } = newDao()
+    const big = makeLargeObj(SMALL_MAX * 3)
+    await dao.save({ id: 'm1', obj: big })
+    await dao.save({ id: 'm2', obj: { small: true } })
+
+    const results = await dao.getByIds(['m1', 'm2'])
+    expect(results.map(r => r.id).sort()).toEqual(['m1', 'm2'])
+    const byId = Object.fromEntries(results.map(r => [r.id, r]))
+    expect(byId['m1']!.obj).toEqual(big)
+  })
+
+  test('patchById on chunked entity re-chunks correctly', async () => {
+    const { dao, db: localDb } = newDao()
+    const initial = makeLargeObj(SMALL_MAX * 3)
+    await dao.save({ id: 'p1', obj: initial })
+
+    await dao.patchById('p1', { obj: { ...initial, extra: 'x' } })
+
+    const back = await dao.getById('p1')
+    expect(back?.obj).toEqual({ ...initial, extra: 'x' })
+    // Storage should still have primary + chunks
+    const ids = Object.keys(localDb.data[TEST_TABLE]!)
+    expect(ids.length).toBeGreaterThan(1)
+    expect(ids).toContain('p1')
+  })
+
+  test('patchByQuery throws when chunking enabled', async () => {
+    const { dao } = newDao()
+    await expect(dao.patchByQuery(dao.query(), { obj: { n: 2 } })).rejects.toThrow(
+      /patchByQuery.*not supported/,
+    )
+  })
+
+  test('patchByIds throws when chunking enabled', async () => {
+    const { dao } = newDao()
+    await expect(dao.patchByIds(['x'], { obj: { n: 2 } })).rejects.toThrow(
+      /patchByQuery.*not supported/,
+    )
+  })
+
+  test('runQueryCount throws on unfiltered query when chunking enabled', async () => {
+    const { dao } = newDao()
+    await expect(dao.query().runQueryCount()).rejects.toThrow(/requires at least one filter/)
+  })
+
+  test('runQueryCount works with a filter', async () => {
+    const { dao } = newDao()
+    await dao.save({ id: 'c1', obj: { n: 1 } })
+    await dao.save({ id: 'c2', obj: { n: 2 } })
+
+    const count = await dao.query().filterEq('id', 'c1').runQueryCount()
+    expect(count).toBe(1)
+  })
+
+  test('entity id matching chunk pattern is rejected even for small entities', async () => {
+    const { dao } = newDao()
+    // Small entity that doesn't need chunking — but the id matches the reserved pattern
+    await expect(dao.save({ id: 'bad__c1', obj: { n: 1 } })).rejects.toThrow(
+      /reserved chunk-id pattern/,
+    )
+    // Large entity that does need chunking
+    await expect(dao.save({ id: 'bad__c1', obj: makeLargeObj(SMALL_MAX * 3) })).rejects.toThrow(
+      /reserved chunk-id pattern/,
+    )
+  })
+
+  test('auto-adds __chunked and __chunks to excludeFromIndexes', async () => {
+    const { dao, db: localDb } = newDao()
+    const saveBatchSpy = vi.spyOn(localDb, 'saveBatch')
+
+    await dao.save({ id: 'ei', obj: { n: 1 } })
+
+    expect(saveBatchSpy).toHaveBeenCalledWith(
+      TEST_TABLE,
+      expect.any(Array),
+      expect.objectContaining({
+        excludeFromIndexes: expect.arrayContaining(['__compressed', '__chunked', '__chunks']),
+      }),
+    )
+    saveBatchSpy.mockRestore()
+  })
+
+  test('deleteByQuery removes chunk rows', async () => {
+    const { dao, db: localDb } = newDao()
+    await dao.save({ id: 'dq1', obj: makeLargeObj(SMALL_MAX * 3) })
+    await dao.save({ id: 'dq2', obj: { n: 1 } })
+
+    const deleted = await dao.deleteByQuery(dao.query())
+    expect(deleted).toBe(2)
+    expect(Object.keys(localDb.data[TEST_TABLE] || {})).toEqual([])
+  })
+
+  test('saveBatch with mix of chunked and non-chunked entities', async () => {
+    const { dao, db: localDb } = newDao()
+    const big = makeLargeObj(SMALL_MAX * 3)
+    await dao.saveBatch([
+      { id: 'b1', obj: big },
+      { id: 'b2', obj: { n: 1 } },
+      { id: 'b3', obj: big },
+    ])
+
+    const results = await dao.getByIds(['b1', 'b2', 'b3'])
+    expect(results.map(r => r.id).sort()).toEqual(['b1', 'b2', 'b3'])
+    const byId = Object.fromEntries(results.map(r => [r.id, r]))
+    expect(byId['b1']!.obj).toEqual(big)
+    expect(byId['b3']!.obj).toEqual(big)
+    expect(byId['b2']!.obj).toEqual({ n: 1 })
+
+    // Storage should have at least 5 rows (3 primaries + chunks for 2 big ones)
+    expect(Object.keys(localDb.data[TEST_TABLE]!).length).toBeGreaterThanOrEqual(5)
+  })
+
+  test('constructor rejects chunk without keys', () => {
+    expect(
+      () =>
+        new CommonDao<Item>({
+          table: TEST_TABLE,
+          db,
+          compress: { keys: [], chunk: true },
+        }),
+    ).toThrow(/compress\.chunk requires compress\.keys to be non-empty/)
   })
 })

--- a/packages/db-lib/src/commondao/common.dao.test.ts
+++ b/packages/db-lib/src/commondao/common.dao.test.ts
@@ -1559,4 +1559,132 @@ describe('auto chunking', () => {
         }),
     ).toThrow(/compress\.chunk requires compress\.keys to be non-empty/)
   })
+
+  test('saveAsDBM + getByIdAsDBM round-trip for chunked entity', async () => {
+    const { dao } = newDao()
+    const big = makeLargeObj(SMALL_MAX * 3)
+    await dao.saveAsDBM({ id: 'dbm1', obj: big } as any)
+    const back = await dao.getByIdAsDBM('dbm1')
+    expect(back?.obj).toEqual(big)
+  })
+
+  test('saveBatchAsDBM + getByIdsAsDBM round-trip for chunked entities', async () => {
+    const { dao } = newDao()
+    const big = makeLargeObj(SMALL_MAX * 3)
+    await dao.saveBatchAsDBM([{ id: 'db1', obj: big } as any, { id: 'db2', obj: { n: 1 } } as any])
+    const back = await dao.getByIdsAsDBM(['db1', 'db2'])
+    expect(back.map(r => r.id).sort()).toEqual(['db1', 'db2'])
+    const byId = Object.fromEntries(back.map(r => [r.id, r]))
+    expect(byId['db1']!.obj).toEqual(big)
+  })
+
+  test('streamSave with chunking writes primaries + chunks', async () => {
+    const { dao, db: localDb } = newDao()
+    const big = makeLargeObj(SMALL_MAX * 3)
+    const { Pipeline } = await import('@naturalcycles/nodejs-lib/stream')
+    const p = Pipeline.fromArray<Item>([
+      { id: 'ss1', obj: big } as any,
+      { id: 'ss2', obj: { n: 1 } } as any,
+      { id: 'ss3', obj: big } as any,
+    ])
+    await dao.streamSave(p as any)
+
+    const results = await dao.getByIds(['ss1', 'ss2', 'ss3'])
+    expect(results.map(r => r.id).sort()).toEqual(['ss1', 'ss2', 'ss3'])
+    const byId = Object.fromEntries(results.map(r => [r.id, r]))
+    expect(byId['ss1']!.obj).toEqual(big)
+    expect(byId['ss3']!.obj).toEqual(big)
+    // Primaries in main table, chunks in chunks table
+    expect(Object.keys(localDb.data[TEST_TABLE]!).sort()).toEqual(['ss1', 'ss2', 'ss3'])
+    expect(Object.keys(localDb.data[`${TEST_TABLE}__chunks`] ?? {}).length).toBeGreaterThan(0)
+  })
+
+  test('streamQueryAsDBM with chunking reassembles per row', async () => {
+    const { dao } = newDao()
+    const big = makeLargeObj(SMALL_MAX * 3)
+    await dao.save({ id: 'sq1', obj: big })
+    await dao.save({ id: 'sq2', obj: { n: 1 } })
+
+    const rows = await dao.streamQueryAsDBM(dao.query()).toArray()
+    expect(rows.map(r => r.id).sort()).toEqual(['sq1', 'sq2'])
+    const byId = Object.fromEntries(rows.map(r => [r.id, r]))
+    expect(byId['sq1']!.obj).toEqual(big)
+  })
+
+  test('multiGet fetches chunked entities across tables', async () => {
+    const { dao } = newDao()
+    const big = makeLargeObj(SMALL_MAX * 3)
+    await dao.save({ id: 'mg1', obj: big })
+    await dao.save({ id: 'mg2', obj: { n: 1 } })
+
+    const result = await CommonDao.multiGet({
+      many: dao.withIds(['mg1', 'mg2']),
+    })
+    expect(result.many.map(r => r.id).sort()).toEqual(['mg1', 'mg2'])
+    const byId = Object.fromEntries(result.many.map(r => [r.id, r]))
+    expect(byId['mg1']!.obj).toEqual(big)
+  })
+
+  test('multiSave writes chunked entities across tables', async () => {
+    const { dao, db: localDb } = newDao()
+    const big = makeLargeObj(SMALL_MAX * 3)
+    await CommonDao.multiSave([{ dao, rows: [{ id: 'ms1', obj: big } as any] }])
+    const back = await dao.getById('ms1')
+    expect(back?.obj).toEqual(big)
+    expect(Object.keys(localDb.data[`${TEST_TABLE}__chunks`] ?? {}).length).toBeGreaterThan(0)
+  })
+
+  test('multiDelete removes chunked entities and their chunks', async () => {
+    const { dao, db: localDb } = newDao()
+    const big = makeLargeObj(SMALL_MAX * 3)
+    await dao.save({ id: 'md1', obj: big })
+    await dao.save({ id: 'md2', obj: { n: 1 } })
+
+    const deleted = await CommonDao.multiDelete([
+      { dao, id: 'md1' },
+      { dao, id: 'md2' },
+    ])
+    expect(deleted).toBe(2)
+    expect(Object.keys(localDb.data[TEST_TABLE]!)).toEqual([])
+    expect(Object.keys(localDb.data[`${TEST_TABLE}__chunks`] ?? {})).toEqual([])
+  })
+
+  test('cfg-independent read: legacy chunked data reads correctly after chunk is turned off', async () => {
+    // Save with chunking enabled
+    const localDb = new InMemoryDB()
+    const chunkedDao = new CommonDao<Item>({
+      table: TEST_TABLE,
+      db: localDb,
+      compress: { keys: ['obj'], chunk: { maxChunkSize: SMALL_MAX } },
+    })
+    const big = makeLargeObj(SMALL_MAX * 3)
+    await chunkedDao.save({ id: 'legacy', obj: big })
+    expect(Object.keys(localDb.data[`${TEST_TABLE}__chunks`] ?? {}).length).toBeGreaterThan(0)
+
+    // Build a new DAO with chunking DISABLED but compression still on
+    const unChunkedDao = new CommonDao<Item>({
+      table: TEST_TABLE,
+      db: localDb,
+      compress: { keys: ['obj'] }, // no .chunk
+    })
+    // Existing chunked data should still read back correctly
+    const back = await unChunkedDao.getById('legacy')
+    expect(back?.obj).toEqual(big)
+  })
+
+  test('filterIn batching: getByIds with > FILTER_IN_BATCH_SIZE chunked primaries', async () => {
+    const { dao } = newDao()
+    const big = makeLargeObj(SMALL_MAX * 3)
+    const ids = Array.from({ length: 40 }, (_, i) => `b${i}`)
+    // Save 40 chunked entities
+    for (const id of ids) {
+      await dao.save({ id, obj: big })
+    }
+    // getByIds with 40 primary ids: should batch the chunks-filterIn (30 + 10)
+    const rows = await dao.getByIds(ids)
+    expect(rows.map(r => r.id).sort()).toEqual([...ids].sort())
+    for (const r of rows) {
+      expect(r.obj).toEqual(big)
+    }
+  })
 })

--- a/packages/db-lib/src/commondao/common.dao.ts
+++ b/packages/db-lib/src/commondao/common.dao.ts
@@ -1229,51 +1229,53 @@ export class CommonDao<
   }
 
   /**
-   * Delete orphan chunks for a batch of primaries after a save. Coalesces candidate chunk ids
-   * across all primaries into a single list, then splits into DELETE_BY_IDS_BATCH_SIZE-sized
-   * batches to respect Datastore's 500-mutations-per-commit limit.
+   * Delete orphan chunks for a batch of primaries after a save.
    *
-   * This implementation blindly deletes every candidate chunk id in the range
-   * `[newN, MAX_CHUNKS_PER_ENTITY)` for each primary. Most ids don't exist and the delete is
-   * idempotent, so the cost is ~99 no-op delete ops per chunked primary — acceptable for most
-   * workloads.
+   * Strategy: for each primary, run `runQueryCount(filterEq('primaryId', id))` to learn the
+   * exact number of chunk rows currently in the chunks table. From that we compute the precise
+   * orphan range `[newN, currentCount]` (inclusive) and delete only those ids.
+   *
+   * Assumes chunks are always written contiguously (chunkIdx 1..N-1 for a primary with
+   * `__chunks: N`) — which the save path guarantees. No composite index required; relies only
+   * on the built-in single-field index on `primaryId`.
    *
    * Showcase alternative (commented out): if you deploy a composite index
-   * `(primaryId ASC, chunkIdx ASC)` on `${table}__chunks`, you can use one range-filtered
-   * `deleteByQuery` per primary that targets exactly the stale chunks — zero id amplification,
-   * no MAX cap needed. Enable this path if orphan-cleanup ops ever show up as a hot spot.
+   * `(primaryId ASC, chunkIdx ASC)` on `${table}__chunks`, you can replace the count-then-delete
+   * with a single range-filtered `deleteByQuery` per primary.
    */
   private async cleanupOrphanChunksForMany(
     table: string,
     primaries: ObjectWithId[],
     opt: CommonDaoOptions,
   ): Promise<void> {
+    const chunksTable = chunksTableFor(table)
+
+    // 1. For each primary, count existing chunk rows.
+    const counts = await pMap(primaries, async primary =>
+      this.cfg.db.runQueryCount(
+        DBQuery.create<ChunkRow>(chunksTable).filterEq('primaryId', primary.id),
+        opt,
+      ),
+    )
+
+    // 2. Compute exact orphan ids per primary. Orphans = rows at chunkIdx in [newN, count].
     const orphanIds: string[] = []
-    for (const primary of primaries) {
+    for (let i = 0; i < primaries.length; i++) {
+      const primary = primaries[i]!
       const newN = (primary as Compressed<any>).__chunks ?? 1
-      if (newN >= MAX_CHUNKS_PER_ENTITY) continue
-      for (let i = newN; i < MAX_CHUNKS_PER_ENTITY; i++) {
-        orphanIds.push(this.chunkIdFor(primary.id, i))
+      const currentCount = counts[i]!
+      // Chunk rows exist at chunkIdx 1..currentCount; orphans are those at chunkIdx >= newN.
+      for (let idx = newN; idx <= currentCount; idx++) {
+        orphanIds.push(this.chunkIdFor(primary.id, idx))
       }
     }
     if (!orphanIds.length) return
 
-    // Chunks table ops go through cfg.db (outside transactional scope).
-    const chunksTable = chunksTableFor(table)
+    // 3. Delete orphan ids in batches of DELETE_BY_IDS_BATCH_SIZE. Chunks table ops go
+    // through cfg.db (outside transactional scope).
     await pMap(_chunk(orphanIds, DELETE_BY_IDS_BATCH_SIZE), batch =>
       this.cfg.db.deleteByIds(chunksTable, batch, opt),
     )
-
-    // --- Showcase: composite-index alternative (requires (primaryId, chunkIdx) index) ---
-    // await pMap(primaries, async primary => {
-    //   const newN = (primary as Compressed<any>).__chunks ?? 1
-    //   await this.cfg.db.deleteByQuery(
-    //     DBQuery.create<ChunkRow>(chunksTableFor(table))
-    //       .filterEq('primaryId', primary.id)
-    //       .filter('chunkIdx', '>=', newN),
-    //     opt,
-    //   )
-    // })
   }
 
   anyToDBM(dbm: undefined, opt?: CommonDaoOptions): null

--- a/packages/db-lib/src/commondao/common.dao.ts
+++ b/packages/db-lib/src/commondao/common.dao.ts
@@ -1,5 +1,5 @@
 import { _isTruthy } from '@naturalcycles/js-lib'
-import { _uniqBy } from '@naturalcycles/js-lib/array/array.util.js'
+import { _chunk, _uniqBy } from '@naturalcycles/js-lib/array/array.util.js'
 import { _sortBy } from '@naturalcycles/js-lib/array/sort.js'
 import { localTime } from '@naturalcycles/js-lib/datetime/localTime.js'
 import { _assert, ErrorMode } from '@naturalcycles/js-lib/error'
@@ -79,6 +79,17 @@ const DEFAULT_MAX_CHUNK_SIZE = 900_000
  * A 100-chunk entity is already ~90 MB compressed — using Datastore for that scale is a misuse.
  */
 const MAX_CHUNKS_PER_ENTITY = 100
+
+/**
+ * Datastore `IN`-filter value limit (historically 30 in Datastore; larger in Firestore Datastore
+ * mode). We batch primary-id lists at this size for chunks-table queries.
+ */
+const FILTER_IN_BATCH_SIZE = 30
+
+/**
+ * Maximum ids per single `deleteByIds` API call (Datastore mutation-per-commit limit).
+ */
+const DELETE_BY_IDS_BATCH_SIZE = 500
 
 /**
  * Lowest common denominator API between supported Databases.
@@ -682,15 +693,11 @@ export class CommonDao<
     }
     await Promise.all(writes)
 
-    // Orphan cleanup per primary (cfg-independent — runs whenever compression is configured,
-    // so legacy chunks from a previously-chunked state get cleaned up even after chunking is
-    // turned off).
+    // Orphan cleanup — coalesce all candidate ids across primaries into one set of batched
+    // deleteByIds calls (respecting Datastore's 500-per-batch limit). Cfg-independent so
+    // legacy chunks get cleaned up even after chunking is turned off.
     if (!this.cfg.compress?.keys?.length) return
-    await pMap(primaries, async primary => {
-      _typeCast<Compressed<DBM>>(primary)
-      const newN = primary.__chunks ?? 1
-      await this.cleanupOrphanChunks(table, primary.id, newN, opt)
-    })
+    await this.cleanupOrphanChunksForMany(table, primaries, opt)
   }
 
   private prepareSaveOptions(
@@ -825,8 +832,15 @@ export class CommonDao<
     q.table = opt.table || q.table
     let deleted = 0
 
-    if (opt.chunkSize) {
-      const { chunkSize, chunkConcurrency = 8 } = opt
+    // When compression is configured, chunks live in `${table}__chunks` which has no
+    // user-queryable fields — we can't translate the user's query onto the chunks kind.
+    // We must fetch primary ids first, then delete primaries + chunks in parallel.
+    //
+    // Default to streaming (chunkSize = 500) to avoid loading all ids into memory on large
+    // deletes. Pass `opt.chunkSize` explicitly to tune.
+    const useStreaming = opt.chunkSize || this.cfg.compress?.keys?.length
+    if (useStreaming) {
+      const { chunkSize = 500, chunkConcurrency = 8 } = opt
 
       await this.cfg.db
         .streamQuery<DBM>(q.select(['id']), opt)
@@ -854,17 +868,6 @@ export class CommonDao<
           ...opt,
         })
         .run()
-    } else if (this.cfg.compress?.keys?.length) {
-      // Chunks have no user-queryable fields, so we can't directly delete by the user's query
-      // on the chunks kind. Get primary ids first, then delete primaries + chunks in parallel.
-      const { rows } = await this.cfg.db.runQuery(q.select(['id']), opt)
-      const ids = rows.map(r => r.id)
-      if (!ids.length) return 0
-      const [primaryDeleted] = await Promise.all([
-        this.cfg.db.deleteByIds(q.table, ids, opt),
-        this.deleteChunksByPrimaryIds(q.table, ids, opt),
-      ])
-      deleted = primaryDeleted
     } else {
       deleted = await this.cfg.db.deleteByQuery(q, opt)
     }
@@ -1086,13 +1089,19 @@ export class CommonDao<
   ): Promise<ChunkRow[]> {
     if (!this.cfg.compress?.keys?.length || !primaryIds.length) return []
     // Chunks table queries always go through cfg.db (DBTransaction has no runQuery).
-    const { rows } = await this.cfg.db.runQuery<ChunkRow>(this.chunksQuery(table, primaryIds), opt)
-    return rows
+    // Batch by FILTER_IN_BATCH_SIZE to respect Datastore's IN-filter value limit.
+    const results = await pMap(_chunk(primaryIds, FILTER_IN_BATCH_SIZE), async batch => {
+      const { rows } = await this.cfg.db.runQuery<ChunkRow>(this.chunksQuery(table, batch), opt)
+      return rows
+    })
+    return results.flat()
   }
 
   /**
    * Builds a query against the chunks table that matches all chunks belonging to the given
    * primary ids. Used by both read paths (fetch-and-reassemble) and delete paths.
+   *
+   * Callers must keep `primaryIds.length <= FILTER_IN_BATCH_SIZE`.
    */
   private chunksQuery(table: string, primaryIds: string[]): DBQuery<ChunkRow> {
     return DBQuery.create<ChunkRow>(chunksTableFor(table)).filterIn('primaryId', primaryIds)
@@ -1102,6 +1111,8 @@ export class CommonDao<
    * Deletes all chunks belonging to the given primary ids. No-op when compression is not
    * configured on this DAO (so callers can fire this speculatively from `Promise.all` without
    * branching).
+   *
+   * Batches by FILTER_IN_BATCH_SIZE to respect Datastore's IN-filter value limit.
    */
   private async deleteChunksByPrimaryIds(
     table: string,
@@ -1109,7 +1120,9 @@ export class CommonDao<
     opt: CommonDaoOptions,
   ): Promise<void> {
     if (!this.cfg.compress?.keys?.length || !primaryIds.length) return
-    await this.cfg.db.deleteByQuery(this.chunksQuery(table, primaryIds), opt)
+    await pMap(_chunk(primaryIds, FILTER_IN_BATCH_SIZE), batch =>
+      this.cfg.db.deleteByQuery(this.chunksQuery(table, batch), opt),
+    )
   }
 
   /**
@@ -1216,40 +1229,51 @@ export class CommonDao<
   }
 
   /**
-   * Delete orphan chunks for a primary whose chunk count shrank (or disappeared entirely).
+   * Delete orphan chunks for a batch of primaries after a save. Coalesces candidate chunk ids
+   * across all primaries into a single list, then splits into DELETE_BY_IDS_BATCH_SIZE-sized
+   * batches to respect Datastore's 500-mutations-per-commit limit.
    *
    * This implementation blindly deletes every candidate chunk id in the range
-   * `[newN, MAX_CHUNKS_PER_ENTITY)`. Most ids don't exist and the delete is idempotent, so
-   * the cost is ~99 no-op delete ops per chunked save — acceptable for most workloads.
+   * `[newN, MAX_CHUNKS_PER_ENTITY)` for each primary. Most ids don't exist and the delete is
+   * idempotent, so the cost is ~99 no-op delete ops per chunked primary — acceptable for most
+   * workloads.
    *
    * Showcase alternative (commented out): if you deploy a composite index
-   * `(primaryId ASC, chunkIdx ASC)` on `${table}__chunks`, you can use a single
-   * range-filtered `deleteByQuery` that targets exactly the stale chunks — zero id
-   * amplification, no MAX cap needed. Enable this path if orphan-cleanup ops ever show
-   * up as a hot spot in your Datastore bill.
+   * `(primaryId ASC, chunkIdx ASC)` on `${table}__chunks`, you can use one range-filtered
+   * `deleteByQuery` per primary that targets exactly the stale chunks — zero id amplification,
+   * no MAX cap needed. Enable this path if orphan-cleanup ops ever show up as a hot spot.
    */
-  private async cleanupOrphanChunks(
+  private async cleanupOrphanChunksForMany(
     table: string,
-    primaryId: string,
-    newN: number,
+    primaries: ObjectWithId[],
     opt: CommonDaoOptions,
   ): Promise<void> {
-    if (newN >= MAX_CHUNKS_PER_ENTITY) return
-
     const orphanIds: string[] = []
-    for (let i = newN; i < MAX_CHUNKS_PER_ENTITY; i++) {
-      orphanIds.push(this.chunkIdFor(primaryId, i))
+    for (const primary of primaries) {
+      const newN = (primary as Compressed<any>).__chunks ?? 1
+      if (newN >= MAX_CHUNKS_PER_ENTITY) continue
+      for (let i = newN; i < MAX_CHUNKS_PER_ENTITY; i++) {
+        orphanIds.push(this.chunkIdFor(primary.id, i))
+      }
     }
+    if (!orphanIds.length) return
+
     // Chunks table ops go through cfg.db (outside transactional scope).
-    await this.cfg.db.deleteByIds(chunksTableFor(table), orphanIds, opt)
+    const chunksTable = chunksTableFor(table)
+    await pMap(_chunk(orphanIds, DELETE_BY_IDS_BATCH_SIZE), batch =>
+      this.cfg.db.deleteByIds(chunksTable, batch, opt),
+    )
 
     // --- Showcase: composite-index alternative (requires (primaryId, chunkIdx) index) ---
-    // await this.cfg.db.deleteByQuery(
-    //   DBQuery.create<ChunkRow>(chunksTableFor(table))
-    //     .filterEq('primaryId', primaryId)
-    //     .filter('chunkIdx', '>=', newN),
-    //   opt,
-    // )
+    // await pMap(primaries, async primary => {
+    //   const newN = (primary as Compressed<any>).__chunks ?? 1
+    //   await this.cfg.db.deleteByQuery(
+    //     DBQuery.create<ChunkRow>(chunksTableFor(table))
+    //       .filterEq('primaryId', primary.id)
+    //       .filter('chunkIdx', '>=', newN),
+    //     opt,
+    //   )
+    // })
   }
 
   anyToDBM(dbm: undefined, opt?: CommonDaoOptions): null
@@ -1515,11 +1539,12 @@ export class CommonDao<
     }
 
     // Collect chunks-cleanup operations for any table whose DAO has compression configured.
+    // Route through `deleteChunksByPrimaryIds` so the filterIn batching applies.
     const chunkDeletes: Promise<unknown>[] = []
     for (const [table, ids] of _stringMapEntries(idsByTable)) {
       const dao = daoByTable[table]
       if (!dao?.cfg.compress?.keys?.length || !ids.length) continue
-      chunkDeletes.push(db.deleteByQuery((dao as any).chunksQuery(table, ids), opt))
+      chunkDeletes.push((dao as any).deleteChunksByPrimaryIds(table, ids, opt))
     }
 
     // Delete primaries and chunks in parallel. Return the primary deletion count.
@@ -1587,14 +1612,12 @@ export class CommonDao<
 
     await db.multiSave(dbmsByTable)
 
-    // Orphan cleanup per primary for any table whose DAO has compression configured.
+    // Orphan cleanup for any table whose DAO has compression configured. Skip rows that live
+    // in a chunks table (`${table}__chunks`) — those aren't primaries.
     for (const [table, rows] of _stringMapEntries(dbmsByTable)) {
       const dao = daoByTable[table]
       if (!dao?.cfg.compress?.keys?.length) continue
-      await pMap(rows, async (primary: any) => {
-        const newN = primary.__chunks ?? 1
-        await (dao as any).cleanupOrphanChunks(table, primary.id, newN, opt)
-      })
+      await (dao as any).cleanupOrphanChunksForMany(table, rows, opt)
     }
   }
 

--- a/packages/db-lib/src/commondao/common.dao.ts
+++ b/packages/db-lib/src/commondao/common.dao.ts
@@ -10,13 +10,6 @@ import {
   _pick,
 } from '@naturalcycles/js-lib/object/object.util.js'
 import { pMap } from '@naturalcycles/js-lib/promise/pMap.js'
-import {
-  _objectKeys,
-  _passthroughPredicate,
-  _stringMapEntries,
-  _stringMapValues,
-  _typeCast,
-} from '@naturalcycles/js-lib/types'
 import type {
   BaseDBEntity,
   NonNegativeInteger,
@@ -24,11 +17,19 @@ import type {
   StringMap,
   Unsaved,
 } from '@naturalcycles/js-lib/types'
+import {
+  _objectKeys,
+  _passthroughPredicate,
+  _stringMapEntries,
+  _stringMapValues,
+  _typeCast,
+} from '@naturalcycles/js-lib/types'
 import { stringId } from '@naturalcycles/nodejs-lib'
 import type { JsonSchema } from '@naturalcycles/nodejs-lib/ajv'
 import type { Pipeline } from '@naturalcycles/nodejs-lib/stream'
 import { zip2 } from '@naturalcycles/nodejs-lib/zip'
 import { DBLibError } from '../cnst.js'
+import { CommonDBType } from '../commondb/common.db.js'
 import type {
   CommonDBSaveOptions,
   CommonDBTransactionOptions,
@@ -53,6 +54,41 @@ import type {
 import { CommonDaoTransaction } from './commonDaoTransaction.js'
 
 /**
+ * Reserved properties used by auto-compression and auto-chunking at the storage layer.
+ * All are excluded from indexes automatically when `compress` is configured.
+ */
+const RESERVED_KEYS = ['__compressed', '__chunked', '__chunks'] as const
+
+/**
+ * Default threshold (in bytes) at which the `__compressed` Buffer is split into chunk rows.
+ * Leaves ~100 KB headroom under Datastore's 1 MB per-entity cap for non-compressed fields + metadata.
+ */
+const DEFAULT_MAX_CHUNK_SIZE = 900_000
+
+/**
+ * Hard cap on the number of storage rows a single chunked entity may occupy.
+ * A 100-chunk entity is already ~90 MB compressed — using Datastore for that scale is a misuse.
+ */
+const MAX_CHUNKS_PER_ENTITY = 100
+
+/**
+ * Chunk ids are formed as `${id}__c${n}` for n >= 1. This matcher identifies a chunk id.
+ */
+const CHUNK_ID_RE = /__c\d+$/
+
+/**
+ * Symbol property stamped on objects returned from the read path when chunking is enabled.
+ * Carries the chunk count from the last read, so the save path can compute the exact orphan
+ * range (`newN..oldN`) instead of blindly deleting up to MAX_CHUNKS_PER_ENTITY.
+ *
+ * Survives `{...obj}` (spread copies own enumerable Symbol properties) but is invisible to
+ * `Object.keys()`, `for..in`, `JSON.stringify()`, and Datastore serialization.
+ *
+ * Falls back to MAX_CHUNKS_PER_ENTITY when absent (new entity or object reconstructed from JSON).
+ */
+const PREV_CHUNKS = Symbol('__prevChunks')
+
+/**
  * Lowest common denominator API between supported Databases.
  *
  * BM = Backend model (optimized for API access)
@@ -61,6 +97,8 @@ import { CommonDaoTransaction } from './commonDaoTransaction.js'
  *
  * Note: When auto-compression is enabled, the physical storage format differs from DBM.
  * Compression/decompression is handled transparently at the storage boundary.
+ * When auto-chunking is additionally enabled, large compressed payloads are split across
+ * multiple storage rows (primary at `id`, extra chunks at `${id}__c${n}`); reassembly is transparent.
  */
 export class CommonDao<
   BM extends BaseDBEntity,
@@ -92,12 +130,32 @@ export class CommonDao<
     }
 
     // If the auto-compression is enabled,
-    // then we need to ensure that the '__compressed' property is part of the index exclusion list.
+    // then we need to ensure that the '__compressed' (and chunking) properties are part of the
+    // index exclusion list.
     if (this.cfg.compress?.keys) {
+      // Auto-compression stores a Buffer in a dedicated `__compressed` property and relies on
+      // `excludeFromIndexes`, both of which are Datastore-specific. Using it with a relational DB
+      // (e.g. MySQL) would require an explicit column/schema and would silently ignore
+      // `excludeFromIndexes` — so we block it at construction time.
+      _assert(
+        this.cfg.db.dbType === CommonDBType.document,
+        `CommonDao "${this.cfg.table}": compress feature is only supported on document DBs (e.g. Datastore), got dbType=${this.cfg.db.dbType}`,
+      )
+
+      // Chunking piggybacks on compression — it only splits the `__compressed` Buffer.
+      if (this.cfg.compress.chunk) {
+        _assert(
+          this.cfg.compress.keys.length > 0,
+          `CommonDao "${this.cfg.table}": compress.chunk requires compress.keys to be non-empty`,
+        )
+      }
+
       const current = this.cfg.excludeFromIndexes
       this.cfg.excludeFromIndexes = current ? [...current] : []
-      if (!this.cfg.excludeFromIndexes.includes('__compressed' as any)) {
-        this.cfg.excludeFromIndexes.push('__compressed' as any)
+      for (const key of RESERVED_KEYS) {
+        if (!this.cfg.excludeFromIndexes.includes(key as any)) {
+          this.cfg.excludeFromIndexes.push(key as any)
+        }
       }
     }
   }
@@ -155,6 +213,9 @@ export class CommonDao<
     if (!ids.length) return []
     const table = opt.table || this.cfg.table
     const rows = await (opt.tx || this.cfg.db).getByIds<DBM>(table, ids, opt)
+    // When chunking is enabled, fetch extra chunks and reassemble __compressed buffers
+    // before decompression.
+    await this.reassembleChunks(table, rows, opt)
     return this.storageRowsToDBM(rows)
   }
 
@@ -216,7 +277,13 @@ export class CommonDao<
     q.table = opt.table || q.table
     const { rows: rawRows, ...queryResult } = await this.cfg.db.runQuery<DBM>(q, opt)
     const isPartialQuery = !!q._selectedFieldNames
-    const rows = isPartialQuery ? rawRows : this.storageRowsToDBM(rawRows)
+    // For partial queries: strip chunk rows but skip decompression.
+    // For full queries: reassembleChunks partitions out chunk rows, uses any locally available
+    // chunks from the query result, and fetches only the missing ones from the DB.
+    const dechunked = isPartialQuery
+      ? this.filterOutChunkRows(rawRows)
+      : await this.reassembleChunks(q.table, rawRows, opt)
+    const rows = isPartialQuery ? dechunked : this.storageRowsToDBM(dechunked)
     const bms = isPartialQuery ? (rows as any[]) : this.dbmsToBM(rows, opt)
     return {
       rows: bms,
@@ -237,7 +304,10 @@ export class CommonDao<
     q.table = opt.table || q.table
     const { rows: rawRows, ...queryResult } = await this.cfg.db.runQuery<DBM>(q, opt)
     const isPartialQuery = !!q._selectedFieldNames
-    const rows = isPartialQuery ? rawRows : this.storageRowsToDBM(rawRows)
+    const dechunked = isPartialQuery
+      ? this.filterOutChunkRows(rawRows)
+      : await this.reassembleChunks(q.table, rawRows, opt)
+    const rows = isPartialQuery ? dechunked : this.storageRowsToDBM(dechunked)
     const dbms = isPartialQuery ? rows : this.anyToDBMs(rows, opt)
     return { rows: dbms, ...queryResult }
   }
@@ -245,6 +315,12 @@ export class CommonDao<
   async runQueryCount(q: DBQuery<DBM>, opt: CommonDaoReadOptions = {}): Promise<number> {
     this.validateQueryIndexes(q) // throws if query uses `excludeFromIndexes` property
     q.table = opt.table || q.table
+    // When chunking is enabled, unfiltered counts would include extra chunk rows.
+    // Chunk rows lack queryable fields so they can't match a filter — we require at least one.
+    _assert(
+      !this.cfg.compress?.chunk || q._filters.length > 0,
+      `CommonDao "${q.table}": runQueryCount requires at least one filter when compress.chunk is enabled (otherwise the count would include extra chunk rows).`,
+    )
     return await this.cfg.db.runQueryCount(q, opt)
   }
 
@@ -253,7 +329,19 @@ export class CommonDao<
     q.table = opt.table || q.table
     let pipeline = this.cfg.db.streamQuery<DBM>(q, opt)
 
-    if (this.cfg.compress?.keys.length) {
+    // When chunking is enabled: drop extra chunk rows, then async-reassemble each primary.
+    if (this.cfg.compress?.chunk) {
+      pipeline = pipeline
+        .filterSync(row => {
+          _typeCast<Compressed<DBM>>(row)
+          return !row.__chunked
+        })
+        .map(async row => {
+          await this.reassembleChunks(q.table, [row], opt)
+          return this.storageRowToDBM(row)
+        })
+    } else if (this.cfg.compress?.keys.length) {
+      // Compression without chunking — sync decompression is sufficient.
       pipeline = pipeline.mapSync(row => this.storageRowToDBM(row))
     }
 
@@ -271,7 +359,19 @@ export class CommonDao<
     q.table = opt.table || q.table
     let pipeline = this.cfg.db.streamQuery<DBM>(q, opt)
 
-    if (this.cfg.compress?.keys.length) {
+    // When chunking is enabled: drop extra chunk rows, then async-reassemble each primary.
+    if (this.cfg.compress?.chunk) {
+      pipeline = pipeline
+        .filterSync(row => {
+          _typeCast<Compressed<DBM>>(row)
+          return !row.__chunked
+        })
+        .map(async row => {
+          await this.reassembleChunks(q.table, [row], opt)
+          return this.storageRowToDBM(row)
+        })
+    } else if (this.cfg.compress?.keys.length) {
+      // Compression without chunking — sync decompression is sufficient.
       pipeline = pipeline.mapSync(row => this.storageRowToDBM(row))
     }
 
@@ -288,7 +388,12 @@ export class CommonDao<
     this.validateQueryIndexes(q) // throws if query uses `excludeFromIndexes` property
     q.table = opt.table || q.table
     const { rows } = await this.cfg.db.runQuery(q.select(['id']), opt)
-    return rows.map(r => r.id as ID)
+    const ids = rows.map(r => r.id as ID)
+    // Filter out extra chunk ids when chunking is enabled.
+    if (this.cfg.compress?.chunk) {
+      return ids.filter(id => !CHUNK_ID_RE.test(id))
+    }
+    return ids
   }
 
   streamQueryIds(q: DBQuery<DBM>, opt: CommonDaoStreamOptions<ID> = {}): Pipeline<ID> {
@@ -296,7 +401,13 @@ export class CommonDao<
     q.table = opt.table || q.table
     opt.errorMode ||= ErrorMode.SUPPRESS
 
-    return this.cfg.db.streamQuery(q.select(['id']), opt).mapSync((r: ObjectWithId) => r.id as ID)
+    let pipeline = this.cfg.db
+      .streamQuery(q.select(['id']), opt)
+      .mapSync((r: ObjectWithId) => r.id as ID)
+    if (this.cfg.compress?.chunk) {
+      pipeline = pipeline.filterSync(id => !CHUNK_ID_RE.test(id as string))
+    }
+    return pipeline
   }
 
   /**
@@ -471,8 +582,9 @@ export class CommonDao<
     const table = opt.table || this.cfg.table
     const saveOptions = this.prepareSaveOptions(opt)
 
-    const row = await this.dbmToStorageRow(dbm)
-    await (opt.tx || this.cfg.db).saveBatch(table, [row], saveOptions)
+    const rows = await this.dbmToStorageRowsWithChunks(dbm)
+    this.propagatePrevChunks(bm, rows)
+    await this.saveWithOrphanCleanup(table, rows, saveOptions, opt)
 
     if (saveOptions.assignGeneratedIds) {
       bm.id = dbm.id
@@ -489,8 +601,9 @@ export class CommonDao<
     const table = opt.table || this.cfg.table
     const saveOptions = this.prepareSaveOptions(opt)
 
-    const row = await this.dbmToStorageRow(validDbm)
-    await (opt.tx || this.cfg.db).saveBatch(table, [row], saveOptions)
+    const rows = await this.dbmToStorageRowsWithChunks(validDbm)
+    this.propagatePrevChunks(dbm, rows)
+    await this.saveWithOrphanCleanup(table, rows, saveOptions, opt)
 
     if (saveOptions.assignGeneratedIds) {
       dbm.id = validDbm.id
@@ -510,8 +623,14 @@ export class CommonDao<
     const table = opt.table || this.cfg.table
     const saveOptions = this.prepareSaveOptions(opt)
 
-    const rows = await this.dbmsToStorageRows(dbms)
-    await (opt.tx || this.cfg.db).saveBatch(table, rows, saveOptions)
+    const rows = (
+      await pMap(dbms, async (dbm, i) => {
+        const r = await this.dbmToStorageRowsWithChunks(dbm)
+        this.propagatePrevChunks(bms[i], r)
+        return r
+      })
+    ).flat()
+    await this.saveWithOrphanCleanup(table, rows, saveOptions, opt)
 
     if (saveOptions.assignGeneratedIds) {
       dbms.forEach((dbm, i) => (bms[i]!.id = dbm.id))
@@ -534,8 +653,14 @@ export class CommonDao<
     const table = opt.table || this.cfg.table
     const saveOptions = this.prepareSaveOptions(opt)
 
-    const rows = await this.dbmsToStorageRows(validDbms)
-    await (opt.tx || this.cfg.db).saveBatch(table, rows, saveOptions)
+    const rows = (
+      await pMap(validDbms, async (validDbm, i) => {
+        const r = await this.dbmToStorageRowsWithChunks(validDbm)
+        this.propagatePrevChunks(dbms[i], r)
+        return r
+      })
+    ).flat()
+    await this.saveWithOrphanCleanup(table, rows, saveOptions, opt)
 
     if (saveOptions.assignGeneratedIds) {
       validDbms.forEach((dbm, i) => (dbms[i]!.id = dbm.id))
@@ -555,11 +680,13 @@ export class CommonDao<
 
     // If the user passed in custom `excludeFromIndexes` with the save() call,
     // and the auto-compression is enabled,
-    // then we need to ensure that the '__compressed' property is part of the list.
+    // then we need to ensure that the reserved compression/chunking properties are in the list.
     if (this.cfg.compress?.keys) {
-      excludeFromIndexes ??= []
-      if (!excludeFromIndexes.includes('__compressed' as any)) {
-        excludeFromIndexes.push('__compressed' as any)
+      excludeFromIndexes = excludeFromIndexes ? [...excludeFromIndexes] : []
+      for (const key of RESERVED_KEYS) {
+        if (!excludeFromIndexes.includes(key as any)) {
+          excludeFromIndexes.push(key as any)
+        }
       }
     }
 
@@ -596,20 +723,39 @@ export class CommonDao<
 
     const { chunkSize = 500, chunkConcurrency = 32, errorMode } = opt
 
+    // When chunking is enabled, each bm may produce multiple rows (primary + extra chunks);
+    // we flatten them into the stream before chunking for db.saveBatch.
+    // After each batch is saved, orphan chunks are cleaned up per primary.
     await p
       .map(
         async bm => {
           this.assignIdCreatedUpdated(bm, opt)
           const dbm = this.bmToDBM(bm, opt)
           beforeSave?.(dbm)
-          return await this.dbmToStorageRow(dbm)
+          return await this.dbmToStorageRowsWithChunks(dbm)
         },
         { errorMode },
       )
+      .flatten<ObjectWithId>()
       .chunk(chunkSize)
       .map(
         async batch => {
           await this.cfg.db.saveBatch(table, batch, saveOptions)
+          if (this.cfg.compress?.chunk) {
+            _typeCast<Compressed<DBM>[]>(batch)
+            const orphanIds: string[] = []
+            for (const row of batch) {
+              if (row.__chunked) continue
+              const newN = row.__chunks ?? 1
+              const oldN: number = (row as any)[PREV_CHUNKS] ?? MAX_CHUNKS_PER_ENTITY
+              for (let i = newN; i < oldN; i++) {
+                orphanIds.push(this.chunkIdFor(row.id, i))
+              }
+            }
+            if (orphanIds.length) {
+              await this.cfg.db.deleteByIds(table, orphanIds, opt)
+            }
+          }
           return batch
         },
         {
@@ -638,7 +784,15 @@ export class CommonDao<
     this.requireWriteAccess()
     this.requireObjectMutability(opt)
     const table = opt.table || this.cfg.table
-    return await (opt.tx || this.cfg.db).deleteByIds(table, ids, opt)
+    const dbOrTx = opt.tx || this.cfg.db
+
+    if (this.cfg.compress?.chunk) {
+      // Expand with all candidate chunk ids — deleteByIds is idempotent for non-existent ids.
+      const allIds = [...(ids as string[]), ...this.candidateChunkIds(ids as string[])]
+      await dbOrTx.deleteByIds(table, allIds, opt)
+      return ids.length
+    }
+    return await dbOrTx.deleteByIds(table, ids, opt)
   }
 
   /**
@@ -656,16 +810,23 @@ export class CommonDao<
     q.table = opt.table || q.table
     let deleted = 0
 
-    if (opt.chunkSize) {
-      const { chunkSize, chunkConcurrency = 8 } = opt
+    // When chunking is enabled, force the streaming path so we can expand each primary id
+    // to include its extra chunks. The direct db.deleteByQuery would otherwise leave chunks behind.
+    const useStreaming = opt.chunkSize || this.cfg.compress?.chunk
+    if (useStreaming) {
+      const { chunkSize = 500, chunkConcurrency = 8 } = opt
 
       await this.cfg.db
         .streamQuery<DBM>(q.select(['id']), opt)
         .mapSync(r => r.id)
+        // Filter out extra chunk ids that may incidentally match the query; we expand
+        // from primaries below.
+        .filterSync(id => (this.cfg.compress?.chunk ? !CHUNK_ID_RE.test(id) : true))
         .chunk(chunkSize)
         .map(
           async ids => {
-            await this.cfg.db.deleteByIds(q.table, ids, opt)
+            const allIds = this.cfg.compress?.chunk ? [...ids, ...this.candidateChunkIds(ids)] : ids
+            await this.cfg.db.deleteByIds(q.table, allIds, opt)
             deleted += ids.length
           },
           {
@@ -699,6 +860,12 @@ export class CommonDao<
     patch: Partial<DBM>,
     opt: CommonDaoOptions = {},
   ): Promise<number> {
+    // patchByQuery bypasses the DAO layer (direct DB mutation). It cannot reassemble / re-chunk
+    // compressed payloads, so we refuse to run when chunking is enabled.
+    _assert(
+      !this.cfg.compress?.chunk,
+      `CommonDao "${this.cfg.table}": patchByQuery / patchByIds are not supported when compress.chunk is enabled. Use patchById (load + save) instead.`,
+    )
     this.validateQueryIndexes(q) // throws if query uses `excludeFromIndexes` property
     this.requireWriteAccess()
     this.requireObjectMutability(opt)
@@ -752,7 +919,15 @@ export class CommonDao<
     const bm = (this.cfg.hooks!.beforeDBMToBM?.(dbm) || dbm) as Partial<BM>
 
     // Validate/convert BM
-    return this.validateAndConvert(bm, 'load', opt)
+    const result = this.validateAndConvert(bm, 'load', opt)
+
+    // Preserve PREV_CHUNKS across the conversion pipeline (validateAndConvert creates a new object
+    // via _filterUndefinedValues which uses Object.entries, dropping Symbol properties).
+    if ((_dbm as any)[PREV_CHUNKS] !== undefined) {
+      ;(result as any)[PREV_CHUNKS] = (_dbm as any)[PREV_CHUNKS]
+    }
+
+    return result
   }
 
   dbmsToBM(dbms: DBM[], opt: CommonDaoOptions = {}): BM[] {
@@ -870,6 +1045,214 @@ export class CommonDao<
     const properties = JSON.parse(bufferString)
     dbm.__compressed = undefined
     Object.assign(dbm, properties)
+  }
+
+  // CHUNKING LAYER (below compression)
+  // Splits the `__compressed` Buffer across multiple storage rows when it exceeds `maxChunkSize`.
+  // Primary row at `id` carries queryable fields + chunk 0 + `__chunks: N`.
+  // Extra chunk rows at `${id}__c${n}` carry only `{ id, __chunked: true, __compressed: <sliceN> }`.
+
+  /**
+   * Returns the chunk id for chunk index `n` (n >= 1) of entity `id`.
+   */
+  private chunkIdFor(id: string, n: number): string {
+    return `${id}__c${n}`
+  }
+
+  /**
+   * Converts a DBM to one or more storage rows, applying compression and — if enabled and needed —
+   * chunking. Returns `[primary, ...extraChunks]`. When no chunking is needed (or disabled),
+   * returns a single-element array.
+   */
+  private async dbmToStorageRowsWithChunks(dbm: DBM): Promise<ObjectWithId[]> {
+    const primary = await this.dbmToStorageRow(dbm)
+    const chunkCfg = this.cfg.compress?.chunk
+    if (!chunkCfg) return [primary]
+
+    _typeCast<Compressed<DBM>>(primary)
+    const compressed = primary.__compressed
+    if (!Buffer.isBuffer(compressed)) return [primary] // Nothing to chunk
+
+    const maxChunkSize =
+      typeof chunkCfg === 'object'
+        ? (chunkCfg.maxChunkSize ?? DEFAULT_MAX_CHUNK_SIZE)
+        : DEFAULT_MAX_CHUNK_SIZE
+
+    // Always validate the id pattern when chunking is enabled — even if this particular entity
+    // fits in one row. An id like `test__c1` would be silently filtered out of queryIds /
+    // streamQueryIds results (which use CHUNK_ID_RE to drop chunk ids).
+    _assert(
+      !CHUNK_ID_RE.test(primary.id),
+      `CommonDao "${this.cfg.table}": entity id "${primary.id}" matches the reserved chunk-id pattern /__c\\d+$/`,
+    )
+
+    if (compressed.length <= maxChunkSize) return [primary] // Fits — single row
+
+    const n = Math.ceil(compressed.length / maxChunkSize)
+    _assert(
+      n <= MAX_CHUNKS_PER_ENTITY,
+      `CommonDao "${this.cfg.table}": entity ${primary.id} compressed payload (${compressed.length} bytes) would require ${n} chunks, exceeding the hard limit of ${MAX_CHUNKS_PER_ENTITY}`,
+    )
+
+    // Use .slice() (copies) rather than .subarray() (view) — subarray pins the entire original
+    // buffer in memory as long as any chunk row is referenced.
+    primary.__compressed = compressed.slice(0, maxChunkSize)
+    primary.__chunks = n
+
+    const extraChunks: ObjectWithId[] = []
+    for (let i = 1; i < n; i++) {
+      extraChunks.push({
+        id: this.chunkIdFor(primary.id, i),
+        __chunked: true,
+        __compressed: compressed.slice(i * maxChunkSize, (i + 1) * maxChunkSize),
+      } as ObjectWithId)
+    }
+    return [primary, ...extraChunks]
+  }
+
+  /**
+   * Accepts a mixed bag of rows (primaries + optional chunk rows). Partitions them internally,
+   * uses locally available chunks first, fetches any missing ones from the DB in a single batch,
+   * reassembles `__compressed` Buffers, and returns only the primaries.
+   *
+   * When called from paths that never include chunk rows (e.g. `loadByIds`), the local-chunk
+   * map is simply empty and everything is fetched — same behavior as before, zero overhead.
+   */
+  private async reassembleChunks<R extends ObjectWithId>(
+    table: string,
+    rows: R[],
+    opt: CommonDaoReadOptions = {},
+  ): Promise<R[]> {
+    if (!this.cfg.compress?.chunk) return rows
+
+    // Partition: primaries (no __chunked) vs locally available chunk rows.
+    const primaries: R[] = []
+    const localChunks = new Map<string, Compressed<any>>()
+    for (const row of rows) {
+      const c = row as Compressed<any>
+      if (c.__chunked) {
+        localChunks.set(c.id, c)
+      } else {
+        primaries.push(row)
+      }
+    }
+
+    // Collect chunk ids needed for reassembly, filtering out locally available ones.
+    const missingChunkIds: string[] = []
+    const chunkOwners: { row: Compressed<any>; chunkCount: number }[] = []
+    for (const row of primaries) {
+      const c = row as Compressed<any>
+      const n = c.__chunks
+      if (typeof n !== 'number' || n <= 1) continue
+      chunkOwners.push({ row: c, chunkCount: n })
+      for (let i = 1; i < n; i++) {
+        const cid = this.chunkIdFor(c.id, i)
+        if (!localChunks.has(cid)) {
+          missingChunkIds.push(cid)
+        }
+      }
+    }
+    if (!chunkOwners.length) return primaries
+
+    // Fetch only the missing chunks from the DB.
+    if (missingChunkIds.length) {
+      const fetched = await (opt.tx || this.cfg.db).getByIds<Compressed<any>>(
+        table,
+        missingChunkIds,
+        opt,
+      )
+      for (const cr of fetched) localChunks.set(cr.id, cr)
+    }
+
+    // Reassemble each chunked primary.
+    for (const { row, chunkCount } of chunkOwners) {
+      const parts: Buffer[] = []
+      if (Buffer.isBuffer(row.__compressed)) parts.push(row.__compressed)
+      for (let i = 1; i < chunkCount; i++) {
+        const cr = localChunks.get(this.chunkIdFor(row.id, i))
+        _assert(
+          cr && Buffer.isBuffer(cr.__compressed),
+          `CommonDao "${this.cfg.table}": missing chunk ${i}/${chunkCount - 1} for entity ${row.id}`,
+        )
+        parts.push(cr.__compressed)
+      }
+      row.__compressed = Buffer.concat(parts)
+      row.__chunks = undefined
+      // Stamp the chunk count so the save path can compute exact orphan range.
+      row[PREV_CHUNKS] = chunkCount
+    }
+    return primaries
+  }
+
+  /**
+   * Carries the PREV_CHUNKS Symbol from a source object (the original BM/DBM the caller passed in)
+   * to the primary storage row (first element of `rows`). The BM→DBM conversion pipeline creates
+   * new objects, dropping the Symbol — this bridges the gap.
+   */
+  private propagatePrevChunks(source: any, rows: ObjectWithId[]): void {
+    if (!this.cfg.compress?.chunk) return
+    const prev = source?.[PREV_CHUNKS]
+    if (prev !== undefined && rows.length) {
+      ;(rows[0] as any)[PREV_CHUNKS] = prev
+    }
+  }
+
+  /**
+   * Post-filter helper: drops extra chunk rows (`__chunked === true`) from a result set.
+   * Used in query paths where chunk rows may incidentally match unfiltered queries.
+   */
+  private filterOutChunkRows<R extends ObjectWithId>(rows: R[]): R[] {
+    if (!this.cfg.compress?.chunk) return rows
+    return rows.filter(r => !(r as Compressed<any>).__chunked)
+  }
+
+  /**
+   * Saves `rows` (which may include primary + extra chunks), then deletes orphan chunk rows
+   * that would otherwise leak after a shrink (e.g. entity went from N=5 → N=2).
+   *
+   * Uses the PREV_CHUNKS Symbol (stamped during reads) to compute the exact orphan range
+   * (`newN..oldN`). Falls back to `newN..MAX_CHUNKS_PER_ENTITY` when the Symbol is absent
+   * (new entity or object not from a DAO read).
+   */
+  private async saveWithOrphanCleanup(
+    table: string,
+    rows: ObjectWithId[],
+    saveOptions: CommonDBSaveOptions<ObjectWithId>,
+    opt: CommonDaoSaveOptions<BM, DBM>,
+  ): Promise<void> {
+    const dbOrTx = opt.tx || this.cfg.db
+    await dbOrTx.saveBatch(table, rows, saveOptions)
+
+    if (!this.cfg.compress?.chunk) return
+
+    // Collect orphan chunk ids across all primaries in one pass, then delete in a single call.
+    _typeCast<Compressed<DBM>[]>(rows)
+    const orphanIds: string[] = []
+    for (const row of rows) {
+      if (row.__chunked) continue
+      const newN = row.__chunks ?? 1
+      const oldN: number = (row as any)[PREV_CHUNKS] ?? MAX_CHUNKS_PER_ENTITY
+      for (let i = newN; i < oldN; i++) {
+        orphanIds.push(this.chunkIdFor(row.id, i))
+      }
+    }
+    if (!orphanIds.length) return
+    await dbOrTx.deleteByIds(table, orphanIds, opt)
+  }
+
+  /**
+   * For a list of primary entity ids, generates all candidate chunk ids (`${id}__c1` through
+   * `${id}__c${MAX-1}`). Used by delete paths — deleteByIds is idempotent for non-existent ids,
+   * so we can blindly delete all candidates without reading anything first.
+   */
+  private candidateChunkIds(ids: string[]): string[] {
+    const result: string[] = []
+    for (const id of ids) {
+      for (let i = 1; i < MAX_CHUNKS_PER_ENTITY; i++) {
+        result.push(this.chunkIdFor(id, i))
+      }
+    }
+    return result
   }
 
   anyToDBM(dbm: undefined, opt?: CommonDaoOptions): null
@@ -1002,9 +1385,35 @@ export class CommonDao<
     // todo: support tx
     const dbmsByTable = await db.multiGet(idsByTable, opt)
 
+    // When any input dao uses chunking, reassemble extra chunks for its primaries.
+    await CommonDao.multiGetReassembleChunks(inputMap, dbmsByTable, opt)
+
     const dbmByTableById = CommonDao.multiGetMapByTableById(dbmsByTable)
 
     return CommonDao.prepareMultiGetOutput(inputMap, dbmByTableById, opt) as any
+  }
+
+  /**
+   * For each table whose input DAO has chunking enabled, fetch extra chunks for any rows
+   * with `__chunks > 1` and reassemble their `__compressed` buffers.
+   */
+  private static async multiGetReassembleChunks(
+    inputMap: StringMap<DaoWithIds<AnyDao> | DaoWithId<AnyDao>>,
+    dbmsByTable: StringMap<ObjectWithId[]>,
+    opt: CommonDaoReadOptions,
+  ): Promise<void> {
+    // Map table -> first dao we see for it (all DAOs for the same table share config shape)
+    const daoByTable: StringMap<AnyDao> = {}
+    for (const input of _stringMapValues(inputMap)) {
+      const { table } = input.dao.cfg
+      daoByTable[table] ||= input.dao
+    }
+
+    for (const [table, rows] of _stringMapEntries(dbmsByTable)) {
+      const dao = daoByTable[table]
+      if (!dao?.cfg.compress?.chunk) continue
+      await (dao as any).reassembleChunks(table, rows, opt)
+    }
   }
 
   private static prepareMultiGetIds(
@@ -1091,17 +1500,28 @@ export class CommonDao<
     if (!inputs.length) return 0
     const { db } = inputs[0]!.dao.cfg
     const idsByTable: StringMap<string[]> = {}
+    // Track dao per table so we can expand ids with chunks below.
+    const daoByTable: StringMap<AnyDao> = {}
     for (const input of inputs) {
       const { dao } = input
       const { table } = dao.cfg
       dao.requireWriteAccess()
       dao.requireObjectMutability(opt)
       idsByTable[table] ||= []
+      daoByTable[table] ||= dao
 
       if ('id' in input) {
         idsByTable[table].push(input.id)
       } else {
         idsByTable[table].push(...input.ids)
+      }
+    }
+
+    // Expand ids with candidate chunk ids for tables whose DAO has chunking enabled.
+    for (const [table, ids] of _stringMapEntries(idsByTable)) {
+      const dao = daoByTable[table]
+      if (dao?.cfg.compress?.chunk) {
+        idsByTable[table] = [...ids, ...(dao as any).candidateChunkIds(ids)]
       }
     }
 
@@ -1115,10 +1535,12 @@ export class CommonDao<
     if (!inputs.length) return
     const { db } = inputs[0]!.dao.cfg
     const dbmsByTable: StringMap<any[]> = {}
+    const daoByTable: StringMap<AnyDao> = {}
     await pMap(inputs, async input => {
       const { dao } = input
       const { table } = dao.cfg
       dbmsByTable[table] ||= []
+      daoByTable[table] ||= dao
 
       if ('row' in input) {
         // Singular
@@ -1138,8 +1560,8 @@ export class CommonDao<
         dao.assignIdCreatedUpdated(row, opt)
         const dbm = dao.bmToDBM(row, opt)
         dao.cfg.hooks!.beforeSave?.(dbm)
-        const storageRow = await dao.dbmToStorageRow(dbm)
-        dbmsByTable[table].push(storageRow)
+        const storageRows = await (dao as any).dbmToStorageRowsWithChunks(dbm)
+        dbmsByTable[table].push(...storageRows)
       } else {
         // Plural
         input.rows.forEach(bm => dao.assignIdCreatedUpdated(bm, opt))
@@ -1147,12 +1569,32 @@ export class CommonDao<
         if (dao.cfg.hooks!.beforeSave) {
           dbms.forEach(dbm => dao.cfg.hooks!.beforeSave!(dbm))
         }
-        const storageRows = await dao.dbmsToStorageRows(dbms)
+        const storageRows = (
+          await pMap(dbms, (dbm: any) => (dao as any).dbmToStorageRowsWithChunks(dbm))
+        ).flat()
         dbmsByTable[table].push(...storageRows)
       }
     })
 
     await db.multiSave(dbmsByTable)
+
+    // Run orphan cleanup for any table whose DAO has chunking enabled — one deleteByIds per table.
+    for (const [table, rows] of _stringMapEntries(dbmsByTable)) {
+      const dao = daoByTable[table]
+      if (!dao?.cfg.compress?.chunk) continue
+      const orphanIds: string[] = []
+      for (const row of rows) {
+        if (row.__chunked) continue
+        const newN = row.__chunks ?? 1
+        const oldN: number = row[PREV_CHUNKS] ?? MAX_CHUNKS_PER_ENTITY
+        for (let i = newN; i < oldN; i++) {
+          orphanIds.push((dao as any).chunkIdFor(row.id, i))
+        }
+      }
+      if (orphanIds.length) {
+        await db.deleteByIds(table, orphanIds, opt)
+      }
+    }
   }
 
   async createTransaction(opt?: CommonDBTransactionOptions): Promise<CommonDaoTransaction> {
@@ -1278,9 +1720,16 @@ export type InferID<DAO> = DAO extends CommonDao<any, any, infer ID> ? ID : neve
 export type AnyDao = CommonDao<any>
 
 /**
- * Represents a DBM whose properties have been compressed into a `data` Buffer.
+ * Represents a DBM whose properties have been compressed into a `__compressed` Buffer.
  *
  * Used internally during compression/decompression so that DBM instances can
  * carry their compressed payload alongside the original type shape.
+ *
+ * `__chunks` is set on the primary row of a chunked entity (total chunk count, N >= 2).
+ * `__chunked` is set to true on extra chunk rows (id suffixed with `__c${n}`).
  */
-type Compressed<DBM> = DBM & { __compressed?: Buffer }
+type Compressed<DBM> = DBM & {
+  __compressed?: Buffer
+  __chunked?: boolean
+  __chunks?: number
+}

--- a/packages/db-lib/src/commondao/common.dao.ts
+++ b/packages/db-lib/src/commondao/common.dao.ts
@@ -1,5 +1,6 @@
 import { _isTruthy } from '@naturalcycles/js-lib'
 import { _uniqBy } from '@naturalcycles/js-lib/array/array.util.js'
+import { _sortBy } from '@naturalcycles/js-lib/array/sort.js'
 import { localTime } from '@naturalcycles/js-lib/datetime/localTime.js'
 import { _assert, ErrorMode } from '@naturalcycles/js-lib/error'
 import { _deepJsonEquals } from '@naturalcycles/js-lib/object/deepEquals.js'
@@ -35,8 +36,7 @@ import type {
   CommonDBTransactionOptions,
   RunQueryResult,
 } from '../db.model.js'
-import type { DBQuery } from '../query/dbQuery.js'
-import { RunnableDBQuery } from '../query/dbQuery.js'
+import { DBQuery, RunnableDBQuery } from '../query/dbQuery.js'
 import type {
   CommonDaoCfg,
   CommonDaoCreateOptions,
@@ -54,10 +54,19 @@ import type {
 import { CommonDaoTransaction } from './commonDaoTransaction.js'
 
 /**
- * Reserved properties used by auto-compression and auto-chunking at the storage layer.
- * All are excluded from indexes automatically when `compress` is configured.
+ * Reserved properties on the PRIMARY row used by auto-compression and auto-chunking.
+ * Excluded from indexes automatically when `compress` is configured.
+ *
+ * Note: chunks live in a dedicated table (`${table}__chunks`), so no `__chunked` marker is needed.
  */
-const RESERVED_KEYS = ['__compressed', '__chunked', '__chunks'] as const
+const PRIMARY_RESERVED_KEYS = ['__compressed', '__chunks'] as const
+
+/**
+ * For chunk rows: only `__compressed` (the Buffer) is excluded from indexes.
+ * `primaryId` and `chunkIdx` ARE indexed — `primaryId` is used for parallel fetches via
+ * `filterIn('primaryId', [...])`.
+ */
+const CHUNK_RESERVED_KEYS = ['__compressed'] as const
 
 /**
  * Default threshold (in bytes) at which the `__compressed` Buffer is split into chunk rows.
@@ -66,27 +75,10 @@ const RESERVED_KEYS = ['__compressed', '__chunked', '__chunks'] as const
 const DEFAULT_MAX_CHUNK_SIZE = 900_000
 
 /**
- * Hard cap on the number of storage rows a single chunked entity may occupy.
+ * Hard cap on the number of chunk rows a single entity may occupy.
  * A 100-chunk entity is already ~90 MB compressed — using Datastore for that scale is a misuse.
  */
 const MAX_CHUNKS_PER_ENTITY = 100
-
-/**
- * Chunk ids are formed as `${id}__c${n}` for n >= 1. This matcher identifies a chunk id.
- */
-const CHUNK_ID_RE = /__c\d+$/
-
-/**
- * Symbol property stamped on objects returned from the read path when chunking is enabled.
- * Carries the chunk count from the last read, so the save path can compute the exact orphan
- * range (`newN..oldN`) instead of blindly deleting up to MAX_CHUNKS_PER_ENTITY.
- *
- * Survives `{...obj}` (spread copies own enumerable Symbol properties) but is invisible to
- * `Object.keys()`, `for..in`, `JSON.stringify()`, and Datastore serialization.
- *
- * Falls back to MAX_CHUNKS_PER_ENTITY when absent (new entity or object reconstructed from JSON).
- */
-const PREV_CHUNKS = Symbol('__prevChunks')
 
 /**
  * Lowest common denominator API between supported Databases.
@@ -152,7 +144,7 @@ export class CommonDao<
 
       const current = this.cfg.excludeFromIndexes
       this.cfg.excludeFromIndexes = current ? [...current] : []
-      for (const key of RESERVED_KEYS) {
+      for (const key of PRIMARY_RESERVED_KEYS) {
         if (!this.cfg.excludeFromIndexes.includes(key as any)) {
           this.cfg.excludeFromIndexes.push(key as any)
         }
@@ -212,11 +204,19 @@ export class CommonDao<
   private async loadByIds(ids: ID[], opt: CommonDaoReadOptions = {}): Promise<DBM[]> {
     if (!ids.length) return []
     const table = opt.table || this.cfg.table
-    const rows = await (opt.tx || this.cfg.db).getByIds<DBM>(table, ids, opt)
-    // When chunking is enabled, fetch extra chunks and reassemble __compressed buffers
-    // before decompression.
-    await this.reassembleChunks(table, rows, opt)
-    return this.storageRowsToDBM(rows)
+    const dbOrTx = opt.tx || this.cfg.db
+
+    // Speculative parallel fetch: primaries + chunks in one round-trip. `fetchChunksByPrimaryIds`
+    // returns [] when compression isn't configured, so Promise.all stays branch-free.
+    // Cfg-independent dechunking: works even after `compress.chunk` is turned off
+    // (reassembly is driven by primary's `__chunks` metadata).
+    const [primaries, chunkRows] = await Promise.all([
+      dbOrTx.getByIds<DBM>(table, ids, opt),
+      this.fetchChunksByPrimaryIds(table, ids, opt),
+    ])
+
+    this.reassembleChunks(primaries, chunkRows)
+    return this.storageRowsToDBM(primaries)
   }
 
   async getBy(by: keyof DBM, value: any, limit = 0, opt?: CommonDaoReadOptions): Promise<BM[]> {
@@ -275,15 +275,15 @@ export class CommonDao<
   ): Promise<RunQueryResult<BM>> {
     this.validateQueryIndexes(q) // throws if query uses `excludeFromIndexes` property
     q.table = opt.table || q.table
-    const { rows: rawRows, ...queryResult } = await this.cfg.db.runQuery<DBM>(q, opt)
+    const { rows: primaries, ...queryResult } = await this.cfg.db.runQuery<DBM>(q, opt)
     const isPartialQuery = !!q._selectedFieldNames
-    // For partial queries: strip chunk rows but skip decompression.
-    // For full queries: reassembleChunks partitions out chunk rows, uses any locally available
-    // chunks from the query result, and fetches only the missing ones from the DB.
-    const dechunked = isPartialQuery
-      ? this.filterOutChunkRows(rawRows)
-      : await this.reassembleChunks(q.table, rawRows, opt)
-    const rows = isPartialQuery ? dechunked : this.storageRowsToDBM(dechunked)
+
+    // Full queries only: fetch chunks for any chunked primaries and reassemble (cfg-independent,
+    // driven by __chunks metadata on returned primaries).
+    if (!isPartialQuery) {
+      await this.fetchAndReassembleChunks(q.table, primaries, opt)
+    }
+    const rows = isPartialQuery ? primaries : this.storageRowsToDBM(primaries)
     const bms = isPartialQuery ? (rows as any[]) : this.dbmsToBM(rows, opt)
     return {
       rows: bms,
@@ -302,25 +302,36 @@ export class CommonDao<
   ): Promise<RunQueryResult<DBM>> {
     this.validateQueryIndexes(q) // throws if query uses `excludeFromIndexes` property
     q.table = opt.table || q.table
-    const { rows: rawRows, ...queryResult } = await this.cfg.db.runQuery<DBM>(q, opt)
+    const { rows: primaries, ...queryResult } = await this.cfg.db.runQuery<DBM>(q, opt)
     const isPartialQuery = !!q._selectedFieldNames
-    const dechunked = isPartialQuery
-      ? this.filterOutChunkRows(rawRows)
-      : await this.reassembleChunks(q.table, rawRows, opt)
-    const rows = isPartialQuery ? dechunked : this.storageRowsToDBM(dechunked)
+    if (!isPartialQuery) {
+      await this.fetchAndReassembleChunks(q.table, primaries, opt)
+    }
+    const rows = isPartialQuery ? primaries : this.storageRowsToDBM(primaries)
     const dbms = isPartialQuery ? rows : this.anyToDBMs(rows, opt)
     return { rows: dbms, ...queryResult }
+  }
+
+  /**
+   * For a batch of primaries, fetch their chunks (one `filterIn('primaryId', ids)` query) and
+   * reassemble in place. Cfg-independent — gated on the presence of `__chunks` metadata.
+   */
+  private async fetchAndReassembleChunks(
+    table: string,
+    primaries: any[],
+    opt: CommonDaoReadOptions,
+  ): Promise<void> {
+    const chunkedIds: string[] = []
+    for (const p of primaries) {
+      if (typeof p.__chunks === 'number' && p.__chunks > 1) chunkedIds.push(p.id)
+    }
+    const chunkRows = await this.fetchChunksByPrimaryIds(table, chunkedIds, opt)
+    this.reassembleChunks(primaries, chunkRows)
   }
 
   async runQueryCount(q: DBQuery<DBM>, opt: CommonDaoReadOptions = {}): Promise<number> {
     this.validateQueryIndexes(q) // throws if query uses `excludeFromIndexes` property
     q.table = opt.table || q.table
-    // When chunking is enabled, unfiltered counts would include extra chunk rows.
-    // Chunk rows lack queryable fields so they can't match a filter — we require at least one.
-    _assert(
-      !this.cfg.compress?.chunk || q._filters.length > 0,
-      `CommonDao "${q.table}": runQueryCount requires at least one filter when compress.chunk is enabled (otherwise the count would include extra chunk rows).`,
-    )
     return await this.cfg.db.runQueryCount(q, opt)
   }
 
@@ -329,20 +340,17 @@ export class CommonDao<
     q.table = opt.table || q.table
     let pipeline = this.cfg.db.streamQuery<DBM>(q, opt)
 
-    // When chunking is enabled: drop extra chunk rows, then async-reassemble each primary.
-    if (this.cfg.compress?.chunk) {
-      pipeline = pipeline
-        .filterSync(row => {
-          _typeCast<Compressed<DBM>>(row)
-          return !row.__chunked
-        })
-        .map(async row => {
-          await this.reassembleChunks(q.table, [row], opt)
-          return this.storageRowToDBM(row)
-        })
-    } else if (this.cfg.compress?.keys.length) {
-      // Compression without chunking — sync decompression is sufficient.
-      pipeline = pipeline.mapSync(row => this.storageRowToDBM(row))
+    // Primaries only — chunks live in a separate table. If compression is configured, we may
+    // need to dechunk (cfg-independent, driven by each primary's __chunks metadata).
+    if (this.cfg.compress?.keys?.length) {
+      pipeline = pipeline.map(async row => {
+        _typeCast<Compressed<DBM>>(row)
+        const n = row.__chunks
+        if (typeof n === 'number' && n > 1) {
+          await this.fetchAndReassembleChunks(q.table, [row], opt)
+        }
+        return this.storageRowToDBM(row)
+      })
     }
 
     const isPartialQuery = !!q._selectedFieldNames
@@ -359,20 +367,15 @@ export class CommonDao<
     q.table = opt.table || q.table
     let pipeline = this.cfg.db.streamQuery<DBM>(q, opt)
 
-    // When chunking is enabled: drop extra chunk rows, then async-reassemble each primary.
-    if (this.cfg.compress?.chunk) {
-      pipeline = pipeline
-        .filterSync(row => {
-          _typeCast<Compressed<DBM>>(row)
-          return !row.__chunked
-        })
-        .map(async row => {
-          await this.reassembleChunks(q.table, [row], opt)
-          return this.storageRowToDBM(row)
-        })
-    } else if (this.cfg.compress?.keys.length) {
-      // Compression without chunking — sync decompression is sufficient.
-      pipeline = pipeline.mapSync(row => this.storageRowToDBM(row))
+    if (this.cfg.compress?.keys?.length) {
+      pipeline = pipeline.map(async row => {
+        _typeCast<Compressed<DBM>>(row)
+        const n = row.__chunks
+        if (typeof n === 'number' && n > 1) {
+          await this.fetchAndReassembleChunks(q.table, [row], opt)
+        }
+        return this.storageRowToDBM(row)
+      })
     }
 
     const isPartialQuery = !!q._selectedFieldNames
@@ -388,12 +391,7 @@ export class CommonDao<
     this.validateQueryIndexes(q) // throws if query uses `excludeFromIndexes` property
     q.table = opt.table || q.table
     const { rows } = await this.cfg.db.runQuery(q.select(['id']), opt)
-    const ids = rows.map(r => r.id as ID)
-    // Filter out extra chunk ids when chunking is enabled.
-    if (this.cfg.compress?.chunk) {
-      return ids.filter(id => !CHUNK_ID_RE.test(id))
-    }
-    return ids
+    return rows.map(r => r.id as ID)
   }
 
   streamQueryIds(q: DBQuery<DBM>, opt: CommonDaoStreamOptions<ID> = {}): Pipeline<ID> {
@@ -401,13 +399,7 @@ export class CommonDao<
     q.table = opt.table || q.table
     opt.errorMode ||= ErrorMode.SUPPRESS
 
-    let pipeline = this.cfg.db
-      .streamQuery(q.select(['id']), opt)
-      .mapSync((r: ObjectWithId) => r.id as ID)
-    if (this.cfg.compress?.chunk) {
-      pipeline = pipeline.filterSync(id => !CHUNK_ID_RE.test(id as string))
-    }
-    return pipeline
+    return this.cfg.db.streamQuery(q.select(['id']), opt).mapSync((r: ObjectWithId) => r.id as ID)
   }
 
   /**
@@ -582,9 +574,8 @@ export class CommonDao<
     const table = opt.table || this.cfg.table
     const saveOptions = this.prepareSaveOptions(opt)
 
-    const rows = await this.dbmToStorageRowsWithChunks(dbm)
-    this.propagatePrevChunks(bm, rows)
-    await this.saveWithOrphanCleanup(table, rows, saveOptions, opt)
+    const { primary, chunks } = await this.dbmToPrimaryAndChunks(dbm)
+    await this.savePrimaryAndChunks(table, [primary], chunks, saveOptions, opt)
 
     if (saveOptions.assignGeneratedIds) {
       bm.id = dbm.id
@@ -601,9 +592,8 @@ export class CommonDao<
     const table = opt.table || this.cfg.table
     const saveOptions = this.prepareSaveOptions(opt)
 
-    const rows = await this.dbmToStorageRowsWithChunks(validDbm)
-    this.propagatePrevChunks(dbm, rows)
-    await this.saveWithOrphanCleanup(table, rows, saveOptions, opt)
+    const { primary, chunks } = await this.dbmToPrimaryAndChunks(validDbm)
+    await this.savePrimaryAndChunks(table, [primary], chunks, saveOptions, opt)
 
     if (saveOptions.assignGeneratedIds) {
       dbm.id = validDbm.id
@@ -623,14 +613,14 @@ export class CommonDao<
     const table = opt.table || this.cfg.table
     const saveOptions = this.prepareSaveOptions(opt)
 
-    const rows = (
-      await pMap(dbms, async (dbm, i) => {
-        const r = await this.dbmToStorageRowsWithChunks(dbm)
-        this.propagatePrevChunks(bms[i], r)
-        return r
-      })
-    ).flat()
-    await this.saveWithOrphanCleanup(table, rows, saveOptions, opt)
+    const primaries: ObjectWithId[] = []
+    const allChunks: ChunkRow[] = []
+    await pMap(dbms, async (dbm, i) => {
+      const { primary, chunks } = await this.dbmToPrimaryAndChunks(dbm)
+      primaries[i] = primary
+      if (chunks.length) allChunks.push(...chunks)
+    })
+    await this.savePrimaryAndChunks(table, primaries, allChunks, saveOptions, opt)
 
     if (saveOptions.assignGeneratedIds) {
       dbms.forEach((dbm, i) => (bms[i]!.id = dbm.id))
@@ -653,20 +643,54 @@ export class CommonDao<
     const table = opt.table || this.cfg.table
     const saveOptions = this.prepareSaveOptions(opt)
 
-    const rows = (
-      await pMap(validDbms, async (validDbm, i) => {
-        const r = await this.dbmToStorageRowsWithChunks(validDbm)
-        this.propagatePrevChunks(dbms[i], r)
-        return r
-      })
-    ).flat()
-    await this.saveWithOrphanCleanup(table, rows, saveOptions, opt)
+    const primaries: ObjectWithId[] = []
+    const allChunks: ChunkRow[] = []
+    await pMap(validDbms, async (validDbm, i) => {
+      const { primary, chunks } = await this.dbmToPrimaryAndChunks(validDbm)
+      primaries[i] = primary
+      if (chunks.length) allChunks.push(...chunks)
+    })
+    await this.savePrimaryAndChunks(table, primaries, allChunks, saveOptions, opt)
 
     if (saveOptions.assignGeneratedIds) {
       validDbms.forEach((dbm, i) => (dbms[i]!.id = dbm.id))
     }
 
     return validDbms
+  }
+
+  /**
+   * Writes primaries to `table` and chunks to `${table}__chunks` in parallel, then cleans up
+   * any orphan chunks per primary. Atomicity is not mitigated — simplicity
+   * first. If either write fails, the other may still succeed (inconsistent state); a subsequent
+   * save fixes it via orphan cleanup.
+   */
+  private async savePrimaryAndChunks(
+    table: string,
+    primaries: ObjectWithId[],
+    chunks: ChunkRow[],
+    primarySaveOptions: CommonDBSaveOptions<ObjectWithId>,
+    opt: CommonDaoSaveOptions<BM, DBM>,
+  ): Promise<void> {
+    const dbOrTx = opt.tx || this.cfg.db
+    const writes: Promise<any>[] = [dbOrTx.saveBatch(table, primaries, primarySaveOptions)]
+    if (chunks.length) {
+      // Chunks table ops go through cfg.db (outside transactional scope).
+      writes.push(
+        this.cfg.db.saveBatch(chunksTableFor(table), chunks as any, this.chunkSaveOptions()),
+      )
+    }
+    await Promise.all(writes)
+
+    // Orphan cleanup per primary (cfg-independent — runs whenever compression is configured,
+    // so legacy chunks from a previously-chunked state get cleaned up even after chunking is
+    // turned off).
+    if (!this.cfg.compress?.keys?.length) return
+    await pMap(primaries, async primary => {
+      _typeCast<Compressed<DBM>>(primary)
+      const newN = primary.__chunks ?? 1
+      await this.cleanupOrphanChunks(table, primary.id, newN, opt)
+    })
   }
 
   private prepareSaveOptions(
@@ -683,7 +707,7 @@ export class CommonDao<
     // then we need to ensure that the reserved compression/chunking properties are in the list.
     if (this.cfg.compress?.keys) {
       excludeFromIndexes = excludeFromIndexes ? [...excludeFromIndexes] : []
-      for (const key of RESERVED_KEYS) {
+      for (const key of PRIMARY_RESERVED_KEYS) {
         if (!excludeFromIndexes.includes(key as any)) {
           excludeFromIndexes.push(key as any)
         }
@@ -723,39 +747,29 @@ export class CommonDao<
 
     const { chunkSize = 500, chunkConcurrency = 32, errorMode } = opt
 
-    // When chunking is enabled, each bm may produce multiple rows (primary + extra chunks);
-    // we flatten them into the stream before chunking for db.saveBatch.
-    // After each batch is saved, orphan chunks are cleaned up per primary.
+    // Convert bm → { primary, chunks } per row, accumulating into a window for batched writes.
+    // For each batch: write primaries to T and all chunks to T__chunks in parallel; then run
+    // orphan cleanup per primary.
     await p
       .map(
         async bm => {
           this.assignIdCreatedUpdated(bm, opt)
           const dbm = this.bmToDBM(bm, opt)
           beforeSave?.(dbm)
-          return await this.dbmToStorageRowsWithChunks(dbm)
+          return await this.dbmToPrimaryAndChunks(dbm)
         },
         { errorMode },
       )
-      .flatten<ObjectWithId>()
       .chunk(chunkSize)
       .map(
         async batch => {
-          await this.cfg.db.saveBatch(table, batch, saveOptions)
-          if (this.cfg.compress?.chunk) {
-            _typeCast<Compressed<DBM>[]>(batch)
-            const orphanIds: string[] = []
-            for (const row of batch) {
-              if (row.__chunked) continue
-              const newN = row.__chunks ?? 1
-              const oldN: number = (row as any)[PREV_CHUNKS] ?? MAX_CHUNKS_PER_ENTITY
-              for (let i = newN; i < oldN; i++) {
-                orphanIds.push(this.chunkIdFor(row.id, i))
-              }
-            }
-            if (orphanIds.length) {
-              await this.cfg.db.deleteByIds(table, orphanIds, opt)
-            }
+          const primaries: ObjectWithId[] = []
+          const chunks: ChunkRow[] = []
+          for (const b of batch) {
+            primaries.push(b.primary)
+            if (b.chunks.length) chunks.push(...b.chunks)
           }
+          await this.savePrimaryAndChunks(table, primaries, chunks, saveOptions, opt)
           return batch
         },
         {
@@ -786,13 +800,14 @@ export class CommonDao<
     const table = opt.table || this.cfg.table
     const dbOrTx = opt.tx || this.cfg.db
 
-    if (this.cfg.compress?.chunk) {
-      // Expand with all candidate chunk ids — deleteByIds is idempotent for non-existent ids.
-      const allIds = [...(ids as string[]), ...this.candidateChunkIds(ids as string[])]
-      await dbOrTx.deleteByIds(table, allIds, opt)
-      return ids.length
-    }
-    return await dbOrTx.deleteByIds(table, ids, opt)
+    // Parallel: delete primaries from T, delete any chunks from T__chunks via filterIn on primaryId.
+    // Cfg-independent: fires the chunks-delete whenever compression is configured, so legacy
+    // chunks are cleaned up even after chunking is turned off.
+    const [primaryDeleted] = await Promise.all([
+      dbOrTx.deleteByIds(table, ids, opt),
+      this.deleteChunksByPrimaryIds(table, ids as string[], opt),
+    ])
+    return primaryDeleted
   }
 
   /**
@@ -810,23 +825,19 @@ export class CommonDao<
     q.table = opt.table || q.table
     let deleted = 0
 
-    // When chunking is enabled, force the streaming path so we can expand each primary id
-    // to include its extra chunks. The direct db.deleteByQuery would otherwise leave chunks behind.
-    const useStreaming = opt.chunkSize || this.cfg.compress?.chunk
-    if (useStreaming) {
-      const { chunkSize = 500, chunkConcurrency = 8 } = opt
+    if (opt.chunkSize) {
+      const { chunkSize, chunkConcurrency = 8 } = opt
 
       await this.cfg.db
         .streamQuery<DBM>(q.select(['id']), opt)
         .mapSync(r => r.id)
-        // Filter out extra chunk ids that may incidentally match the query; we expand
-        // from primaries below.
-        .filterSync(id => (this.cfg.compress?.chunk ? !CHUNK_ID_RE.test(id) : true))
         .chunk(chunkSize)
         .map(
           async ids => {
-            const allIds = this.cfg.compress?.chunk ? [...ids, ...this.candidateChunkIds(ids)] : ids
-            await this.cfg.db.deleteByIds(q.table, allIds, opt)
+            await Promise.all([
+              this.cfg.db.deleteByIds(q.table, ids, opt),
+              this.deleteChunksByPrimaryIds(q.table, ids, opt),
+            ])
             deleted += ids.length
           },
           {
@@ -843,6 +854,17 @@ export class CommonDao<
           ...opt,
         })
         .run()
+    } else if (this.cfg.compress?.keys?.length) {
+      // Chunks have no user-queryable fields, so we can't directly delete by the user's query
+      // on the chunks kind. Get primary ids first, then delete primaries + chunks in parallel.
+      const { rows } = await this.cfg.db.runQuery(q.select(['id']), opt)
+      const ids = rows.map(r => r.id)
+      if (!ids.length) return 0
+      const [primaryDeleted] = await Promise.all([
+        this.cfg.db.deleteByIds(q.table, ids, opt),
+        this.deleteChunksByPrimaryIds(q.table, ids, opt),
+      ])
+      deleted = primaryDeleted
     } else {
       deleted = await this.cfg.db.deleteByQuery(q, opt)
     }
@@ -919,15 +941,7 @@ export class CommonDao<
     const bm = (this.cfg.hooks!.beforeDBMToBM?.(dbm) || dbm) as Partial<BM>
 
     // Validate/convert BM
-    const result = this.validateAndConvert(bm, 'load', opt)
-
-    // Preserve PREV_CHUNKS across the conversion pipeline (validateAndConvert creates a new object
-    // via _filterUndefinedValues which uses Object.entries, dropping Symbol properties).
-    if ((_dbm as any)[PREV_CHUNKS] !== undefined) {
-      ;(result as any)[PREV_CHUNKS] = (_dbm as any)[PREV_CHUNKS]
-    }
-
-    return result
+    return this.validateAndConvert(bm, 'load', opt)
   }
 
   dbmsToBM(dbms: DBM[], opt: CommonDaoOptions = {}): BM[] {
@@ -1048,45 +1062,77 @@ export class CommonDao<
   }
 
   // CHUNKING LAYER (below compression)
-  // Splits the `__compressed` Buffer across multiple storage rows when it exceeds `maxChunkSize`.
-  // Primary row at `id` carries queryable fields + chunk 0 + `__chunks: N`.
-  // Extra chunk rows at `${id}__c${n}` carry only `{ id, __chunked: true, __compressed: <sliceN> }`.
+  // Primaries live in the configured table; chunks live in `${table}__chunks`.
+  // Primary row carries queryable fields + chunk 0 in `__compressed` + `__chunks: N` (when N > 1).
+  // Chunk rows: `{ id, primaryId, chunkIdx, __compressed }`. `primaryId` is indexed for
+  // parallel fetch via `filterIn('primaryId', [...])`.
 
   /**
-   * Returns the chunk id for chunk index `n` (n >= 1) of entity `id`.
+   * Deterministic chunk id: `${primaryId}__c${chunkIdx}`. Kept for debuggability and for
+   * id-based orphan cleanup via deleteByIds.
    */
-  private chunkIdFor(id: string, n: number): string {
-    return `${id}__c${n}`
+  private chunkIdFor(primaryId: string, chunkIdx: number): string {
+    return `${primaryId}__c${chunkIdx}`
   }
 
   /**
-   * Converts a DBM to one or more storage rows, applying compression and — if enabled and needed —
-   * chunking. Returns `[primary, ...extraChunks]`. When no chunking is needed (or disabled),
-   * returns a single-element array.
+   * Fetches chunks for the given primary ids. Returns `[]` if compression is not configured
+   * on this DAO (so callers can fire this speculatively from `Promise.all` without branching).
    */
-  private async dbmToStorageRowsWithChunks(dbm: DBM): Promise<ObjectWithId[]> {
+  private async fetchChunksByPrimaryIds(
+    table: string,
+    primaryIds: string[],
+    opt: CommonDaoReadOptions,
+  ): Promise<ChunkRow[]> {
+    if (!this.cfg.compress?.keys?.length || !primaryIds.length) return []
+    // Chunks table queries always go through cfg.db (DBTransaction has no runQuery).
+    const { rows } = await this.cfg.db.runQuery<ChunkRow>(this.chunksQuery(table, primaryIds), opt)
+    return rows
+  }
+
+  /**
+   * Builds a query against the chunks table that matches all chunks belonging to the given
+   * primary ids. Used by both read paths (fetch-and-reassemble) and delete paths.
+   */
+  private chunksQuery(table: string, primaryIds: string[]): DBQuery<ChunkRow> {
+    return DBQuery.create<ChunkRow>(chunksTableFor(table)).filterIn('primaryId', primaryIds)
+  }
+
+  /**
+   * Deletes all chunks belonging to the given primary ids. No-op when compression is not
+   * configured on this DAO (so callers can fire this speculatively from `Promise.all` without
+   * branching).
+   */
+  private async deleteChunksByPrimaryIds(
+    table: string,
+    primaryIds: string[],
+    opt: CommonDaoOptions,
+  ): Promise<void> {
+    if (!this.cfg.compress?.keys?.length || !primaryIds.length) return
+    await this.cfg.db.deleteByQuery(this.chunksQuery(table, primaryIds), opt)
+  }
+
+  /**
+   * Converts a DBM to a primary row and (if chunking is enabled and payload exceeds the threshold)
+   * an array of chunk rows for the chunks table. Returns `{ primary, chunks }`.
+   */
+  private async dbmToPrimaryAndChunks(
+    dbm: DBM,
+  ): Promise<{ primary: ObjectWithId; chunks: ChunkRow[] }> {
     const primary = await this.dbmToStorageRow(dbm)
     const chunkCfg = this.cfg.compress?.chunk
-    if (!chunkCfg) return [primary]
+    if (!chunkCfg) return { primary, chunks: [] }
 
     _typeCast<Compressed<DBM>>(primary)
     const compressed = primary.__compressed
-    if (!Buffer.isBuffer(compressed)) return [primary] // Nothing to chunk
+    if (!Buffer.isBuffer(compressed)) return { primary, chunks: [] }
 
     const maxChunkSize =
       typeof chunkCfg === 'object'
         ? (chunkCfg.maxChunkSize ?? DEFAULT_MAX_CHUNK_SIZE)
         : DEFAULT_MAX_CHUNK_SIZE
 
-    // Always validate the id pattern when chunking is enabled — even if this particular entity
-    // fits in one row. An id like `test__c1` would be silently filtered out of queryIds /
-    // streamQueryIds results (which use CHUNK_ID_RE to drop chunk ids).
-    _assert(
-      !CHUNK_ID_RE.test(primary.id),
-      `CommonDao "${this.cfg.table}": entity id "${primary.id}" matches the reserved chunk-id pattern /__c\\d+$/`,
-    )
-
-    if (compressed.length <= maxChunkSize) return [primary] // Fits — single row
+    if (compressed.length <= maxChunkSize) return { primary, chunks: [] }
 
     const n = Math.ceil(compressed.length / maxChunkSize)
     _assert(
@@ -1094,165 +1140,116 @@ export class CommonDao<
       `CommonDao "${this.cfg.table}": entity ${primary.id} compressed payload (${compressed.length} bytes) would require ${n} chunks, exceeding the hard limit of ${MAX_CHUNKS_PER_ENTITY}`,
     )
 
-    // Use .slice() (copies) rather than .subarray() (view) — subarray pins the entire original
-    // buffer in memory as long as any chunk row is referenced.
-    primary.__compressed = compressed.slice(0, maxChunkSize)
+    // Use `Buffer.from(subarray)` to COPY the bytes. `subarray` alone returns a view that pins
+    // the entire original buffer in memory as long as any chunk references it; `Buffer.slice`
+    // is deprecated. `Buffer.from(Uint8Array)` allocates and copies.
+    primary.__compressed = Buffer.from(compressed.subarray(0, maxChunkSize))
     primary.__chunks = n
 
-    const extraChunks: ObjectWithId[] = []
+    const chunks: ChunkRow[] = []
     for (let i = 1; i < n; i++) {
-      extraChunks.push({
+      chunks.push({
         id: this.chunkIdFor(primary.id, i),
-        __chunked: true,
-        __compressed: compressed.slice(i * maxChunkSize, (i + 1) * maxChunkSize),
-      } as ObjectWithId)
+        primaryId: primary.id,
+        chunkIdx: i,
+        __compressed: Buffer.from(compressed.subarray(i * maxChunkSize, (i + 1) * maxChunkSize)),
+      })
     }
-    return [primary, ...extraChunks]
+    return { primary, chunks }
   }
 
   /**
-   * Accepts a mixed bag of rows (primaries + optional chunk rows). Partitions them internally,
-   * uses locally available chunks first, fetches any missing ones from the DB in a single batch,
-   * reassembles `__compressed` Buffers, and returns only the primaries.
+   * Reassembles chunked primaries in place. Cfg-independent — driven entirely by primary's
+   * `__chunks: N` metadata. Works even after `compress.chunk` is turned off (legacy data
+   * continues to read correctly until each entity is re-saved).
    *
-   * When called from paths that never include chunk rows (e.g. `loadByIds`), the local-chunk
-   * map is simply empty and everything is fetched — same behavior as before, zero overhead.
+   * `chunkRows` is the union of all chunks fetched from the chunks table for this set of
+   * primaries. Orphans (chunks without a live primary, or beyond the primary's declared N)
+   * are tolerated and ignored.
    */
-  private async reassembleChunks<R extends ObjectWithId>(
-    table: string,
-    rows: R[],
-    opt: CommonDaoReadOptions = {},
-  ): Promise<R[]> {
-    if (!this.cfg.compress?.chunk) return rows
+  private reassembleChunks(primaries: ObjectWithId[], chunkRows: ChunkRow[]): void {
+    if (!chunkRows.length) return
 
-    // Partition: primaries (no __chunked) vs locally available chunk rows.
-    const primaries: R[] = []
-    const localChunks = new Map<string, Compressed<any>>()
-    for (const row of rows) {
-      const c = row as Compressed<any>
-      if (c.__chunked) {
-        localChunks.set(c.id, c)
-      } else {
-        primaries.push(row)
-      }
+    // Group chunks by primaryId and sort each group by chunkIdx ascending.
+    const chunksByPrimaryId = new Map<string, ChunkRow[]>()
+    for (const cr of chunkRows) {
+      const list = chunksByPrimaryId.get(cr.primaryId) ?? []
+      list.push(cr)
+      chunksByPrimaryId.set(cr.primaryId, list)
+    }
+    for (const list of chunksByPrimaryId.values()) {
+      _sortBy(list, chunk => chunk.chunkIdx, { mutate: true })
     }
 
-    // Collect chunk ids needed for reassembly, filtering out locally available ones.
-    const missingChunkIds: string[] = []
-    const chunkOwners: { row: Compressed<any>; chunkCount: number }[] = []
     for (const row of primaries) {
-      const c = row as Compressed<any>
-      const n = c.__chunks
+      const primary = row as Compressed<any>
+      const n = primary.__chunks
       if (typeof n !== 'number' || n <= 1) continue
-      chunkOwners.push({ row: c, chunkCount: n })
-      for (let i = 1; i < n; i++) {
-        const cid = this.chunkIdFor(c.id, i)
-        if (!localChunks.has(cid)) {
-          missingChunkIds.push(cid)
-        }
-      }
-    }
-    if (!chunkOwners.length) return primaries
 
-    // Fetch only the missing chunks from the DB.
-    if (missingChunkIds.length) {
-      const fetched = await (opt.tx || this.cfg.db).getByIds<Compressed<any>>(
-        table,
-        missingChunkIds,
-        opt,
-      )
-      for (const cr of fetched) localChunks.set(cr.id, cr)
-    }
+      const chunksOfPrimary = chunksByPrimaryId.get(primary.id) ?? []
 
-    // Reassemble each chunked primary.
-    for (const { row, chunkCount } of chunkOwners) {
       const parts: Buffer[] = []
-      if (Buffer.isBuffer(row.__compressed)) parts.push(row.__compressed)
-      for (let i = 1; i < chunkCount; i++) {
-        const cr = localChunks.get(this.chunkIdFor(row.id, i))
+      if (Buffer.isBuffer(primary.__compressed)) parts.push(primary.__compressed)
+      // chunksOfPrimary[pos] is expected to have chunkIdx === pos + 1
+      // (chunkIdx 0 is the primary's own `__compressed`; extra chunks are 1..n-1).
+      const expectedCount = n - 1
+      for (let pos = 0; pos < expectedCount; pos++) {
+        const cr = chunksOfPrimary[pos]
+        const chunkIdx = pos + 1
         _assert(
-          cr && Buffer.isBuffer(cr.__compressed),
-          `CommonDao "${this.cfg.table}": missing chunk ${i}/${chunkCount - 1} for entity ${row.id}`,
+          cr && cr.chunkIdx === chunkIdx && Buffer.isBuffer(cr.__compressed),
+          `CommonDao "${this.cfg.table}": missing chunk ${chunkIdx}/${expectedCount} for entity ${primary.id}`,
         )
         parts.push(cr.__compressed)
       }
-      row.__compressed = Buffer.concat(parts)
-      row.__chunks = undefined
-      // Stamp the chunk count so the save path can compute exact orphan range.
-      row[PREV_CHUNKS] = chunkCount
-    }
-    return primaries
-  }
-
-  /**
-   * Carries the PREV_CHUNKS Symbol from a source object (the original BM/DBM the caller passed in)
-   * to the primary storage row (first element of `rows`). The BM→DBM conversion pipeline creates
-   * new objects, dropping the Symbol — this bridges the gap.
-   */
-  private propagatePrevChunks(source: any, rows: ObjectWithId[]): void {
-    if (!this.cfg.compress?.chunk) return
-    const prev = source?.[PREV_CHUNKS]
-    if (prev !== undefined && rows.length) {
-      ;(rows[0] as any)[PREV_CHUNKS] = prev
+      primary.__compressed = Buffer.concat(parts)
+      primary.__chunks = undefined
     }
   }
 
   /**
-   * Post-filter helper: drops extra chunk rows (`__chunked === true`) from a result set.
-   * Used in query paths where chunk rows may incidentally match unfiltered queries.
+   * Save options for chunk rows. Only `__compressed` is excluded from indexes — `primaryId`
+   * and `chunkIdx` ARE indexed so we can query chunks by primaryId cheaply.
    */
-  private filterOutChunkRows<R extends ObjectWithId>(rows: R[]): R[] {
-    if (!this.cfg.compress?.chunk) return rows
-    return rows.filter(r => !(r as Compressed<any>).__chunked)
+  private chunkSaveOptions(): CommonDBSaveOptions<ObjectWithId> {
+    return { excludeFromIndexes: [...CHUNK_RESERVED_KEYS] as any }
   }
 
   /**
-   * Saves `rows` (which may include primary + extra chunks), then deletes orphan chunk rows
-   * that would otherwise leak after a shrink (e.g. entity went from N=5 → N=2).
+   * Delete orphan chunks for a primary whose chunk count shrank (or disappeared entirely).
    *
-   * Uses the PREV_CHUNKS Symbol (stamped during reads) to compute the exact orphan range
-   * (`newN..oldN`). Falls back to `newN..MAX_CHUNKS_PER_ENTITY` when the Symbol is absent
-   * (new entity or object not from a DAO read).
+   * This implementation blindly deletes every candidate chunk id in the range
+   * `[newN, MAX_CHUNKS_PER_ENTITY)`. Most ids don't exist and the delete is idempotent, so
+   * the cost is ~99 no-op delete ops per chunked save — acceptable for most workloads.
+   *
+   * Showcase alternative (commented out): if you deploy a composite index
+   * `(primaryId ASC, chunkIdx ASC)` on `${table}__chunks`, you can use a single
+   * range-filtered `deleteByQuery` that targets exactly the stale chunks — zero id
+   * amplification, no MAX cap needed. Enable this path if orphan-cleanup ops ever show
+   * up as a hot spot in your Datastore bill.
    */
-  private async saveWithOrphanCleanup(
+  private async cleanupOrphanChunks(
     table: string,
-    rows: ObjectWithId[],
-    saveOptions: CommonDBSaveOptions<ObjectWithId>,
-    opt: CommonDaoSaveOptions<BM, DBM>,
+    primaryId: string,
+    newN: number,
+    opt: CommonDaoOptions,
   ): Promise<void> {
-    const dbOrTx = opt.tx || this.cfg.db
-    await dbOrTx.saveBatch(table, rows, saveOptions)
+    if (newN >= MAX_CHUNKS_PER_ENTITY) return
 
-    if (!this.cfg.compress?.chunk) return
-
-    // Collect orphan chunk ids across all primaries in one pass, then delete in a single call.
-    _typeCast<Compressed<DBM>[]>(rows)
     const orphanIds: string[] = []
-    for (const row of rows) {
-      if (row.__chunked) continue
-      const newN = row.__chunks ?? 1
-      const oldN: number = (row as any)[PREV_CHUNKS] ?? MAX_CHUNKS_PER_ENTITY
-      for (let i = newN; i < oldN; i++) {
-        orphanIds.push(this.chunkIdFor(row.id, i))
-      }
+    for (let i = newN; i < MAX_CHUNKS_PER_ENTITY; i++) {
+      orphanIds.push(this.chunkIdFor(primaryId, i))
     }
-    if (!orphanIds.length) return
-    await dbOrTx.deleteByIds(table, orphanIds, opt)
-  }
+    // Chunks table ops go through cfg.db (outside transactional scope).
+    await this.cfg.db.deleteByIds(chunksTableFor(table), orphanIds, opt)
 
-  /**
-   * For a list of primary entity ids, generates all candidate chunk ids (`${id}__c1` through
-   * `${id}__c${MAX-1}`). Used by delete paths — deleteByIds is idempotent for non-existent ids,
-   * so we can blindly delete all candidates without reading anything first.
-   */
-  private candidateChunkIds(ids: string[]): string[] {
-    const result: string[] = []
-    for (const id of ids) {
-      for (let i = 1; i < MAX_CHUNKS_PER_ENTITY; i++) {
-        result.push(this.chunkIdFor(id, i))
-      }
-    }
-    return result
+    // --- Showcase: composite-index alternative (requires (primaryId, chunkIdx) index) ---
+    // await this.cfg.db.deleteByQuery(
+    //   DBQuery.create<ChunkRow>(chunksTableFor(table))
+    //     .filterEq('primaryId', primaryId)
+    //     .filter('chunkIdx', '>=', newN),
+    //   opt,
+    // )
   }
 
   anyToDBM(dbm: undefined, opt?: CommonDaoOptions): null
@@ -1394,25 +1391,25 @@ export class CommonDao<
   }
 
   /**
-   * For each table whose input DAO has chunking enabled, fetch extra chunks for any rows
-   * with `__chunks > 1` and reassemble their `__compressed` buffers.
+   * For each table whose input DAO has compression configured, fetch the primaries' chunks
+   * from `${table}__chunks` and reassemble in place. Cfg-independent dechunking — driven by
+   * primary's __chunks metadata.
    */
   private static async multiGetReassembleChunks(
     inputMap: StringMap<DaoWithIds<AnyDao> | DaoWithId<AnyDao>>,
     dbmsByTable: StringMap<ObjectWithId[]>,
     opt: CommonDaoReadOptions,
   ): Promise<void> {
-    // Map table -> first dao we see for it (all DAOs for the same table share config shape)
     const daoByTable: StringMap<AnyDao> = {}
     for (const input of _stringMapValues(inputMap)) {
       const { table } = input.dao.cfg
       daoByTable[table] ||= input.dao
     }
 
-    for (const [table, rows] of _stringMapEntries(dbmsByTable)) {
+    for (const [table, primaries] of _stringMapEntries(dbmsByTable)) {
       const dao = daoByTable[table]
-      if (!dao?.cfg.compress?.chunk) continue
-      await (dao as any).reassembleChunks(table, rows, opt)
+      if (!dao?.cfg.compress?.keys?.length) continue
+      await (dao as any).fetchAndReassembleChunks(table, primaries, opt)
     }
   }
 
@@ -1517,15 +1514,17 @@ export class CommonDao<
       }
     }
 
-    // Expand ids with candidate chunk ids for tables whose DAO has chunking enabled.
+    // Collect chunks-cleanup operations for any table whose DAO has compression configured.
+    const chunkDeletes: Promise<unknown>[] = []
     for (const [table, ids] of _stringMapEntries(idsByTable)) {
       const dao = daoByTable[table]
-      if (dao?.cfg.compress?.chunk) {
-        idsByTable[table] = [...ids, ...(dao as any).candidateChunkIds(ids)]
-      }
+      if (!dao?.cfg.compress?.keys?.length || !ids.length) continue
+      chunkDeletes.push(db.deleteByQuery((dao as any).chunksQuery(table, ids), opt))
     }
 
-    return await db.multiDelete(idsByTable, opt)
+    // Delete primaries and chunks in parallel. Return the primary deletion count.
+    const [deletedCount] = await Promise.all([db.multiDelete(idsByTable, opt), ...chunkDeletes])
+    return deletedCount
   }
 
   static async multiSave(
@@ -1560,8 +1559,13 @@ export class CommonDao<
         dao.assignIdCreatedUpdated(row, opt)
         const dbm = dao.bmToDBM(row, opt)
         dao.cfg.hooks!.beforeSave?.(dbm)
-        const storageRows = await (dao as any).dbmToStorageRowsWithChunks(dbm)
-        dbmsByTable[table].push(...storageRows)
+        const { primary, chunks } = await (dao as any).dbmToPrimaryAndChunks(dbm)
+        dbmsByTable[table].push(primary)
+        if (chunks.length) {
+          const ct = chunksTableFor(table)
+          dbmsByTable[ct] ||= []
+          dbmsByTable[ct].push(...chunks)
+        }
       } else {
         // Plural
         input.rows.forEach(bm => dao.assignIdCreatedUpdated(bm, opt))
@@ -1569,31 +1573,28 @@ export class CommonDao<
         if (dao.cfg.hooks!.beforeSave) {
           dbms.forEach(dbm => dao.cfg.hooks!.beforeSave!(dbm))
         }
-        const storageRows = (
-          await pMap(dbms, (dbm: any) => (dao as any).dbmToStorageRowsWithChunks(dbm))
-        ).flat()
-        dbmsByTable[table].push(...storageRows)
+        await pMap(dbms, async (dbm: any) => {
+          const { primary, chunks } = await (dao as any).dbmToPrimaryAndChunks(dbm)
+          dbmsByTable[table]!.push(primary)
+          if (chunks.length) {
+            const ct = chunksTableFor(table)
+            dbmsByTable[ct] ||= []
+            dbmsByTable[ct].push(...chunks)
+          }
+        })
       }
     })
 
     await db.multiSave(dbmsByTable)
 
-    // Run orphan cleanup for any table whose DAO has chunking enabled — one deleteByIds per table.
+    // Orphan cleanup per primary for any table whose DAO has compression configured.
     for (const [table, rows] of _stringMapEntries(dbmsByTable)) {
       const dao = daoByTable[table]
-      if (!dao?.cfg.compress?.chunk) continue
-      const orphanIds: string[] = []
-      for (const row of rows) {
-        if (row.__chunked) continue
-        const newN = row.__chunks ?? 1
-        const oldN: number = row[PREV_CHUNKS] ?? MAX_CHUNKS_PER_ENTITY
-        for (let i = newN; i < oldN; i++) {
-          orphanIds.push((dao as any).chunkIdFor(row.id, i))
-        }
-      }
-      if (orphanIds.length) {
-        await db.deleteByIds(table, orphanIds, opt)
-      }
+      if (!dao?.cfg.compress?.keys?.length) continue
+      await pMap(rows, async (primary: any) => {
+        const newN = primary.__chunks ?? 1
+        await (dao as any).cleanupOrphanChunks(table, primary.id, newN, opt)
+      })
     }
   }
 
@@ -1682,6 +1683,13 @@ export class CommonDao<
 }
 
 /**
+ * Derives the chunks-table name for a given primary table. Chunks live in a dedicated kind.
+ */
+function chunksTableFor(table: string): string {
+  return `${table}__chunks`
+}
+
+/**
  * Transaction is committed when the function returns resolved Promise (aka "returns normally").
  *
  * Transaction is rolled back when the function returns rejected Promise (aka "throws").
@@ -1720,16 +1728,23 @@ export type InferID<DAO> = DAO extends CommonDao<any, any, infer ID> ? ID : neve
 export type AnyDao = CommonDao<any>
 
 /**
- * Represents a DBM whose properties have been compressed into a `__compressed` Buffer.
+ * Represents a PRIMARY row whose properties have been compressed into a `__compressed` Buffer.
  *
- * Used internally during compression/decompression so that DBM instances can
- * carry their compressed payload alongside the original type shape.
- *
- * `__chunks` is set on the primary row of a chunked entity (total chunk count, N >= 2).
- * `__chunked` is set to true on extra chunk rows (id suffixed with `__c${n}`).
+ * `__chunks: N` is set on the primary row of a chunked entity (total chunk count, N >= 2).
+ * The first chunk's bytes live in `__compressed` on the primary; chunks 1..N-1 live in
+ * the dedicated chunks table (`${table}__chunks`).
  */
 type Compressed<DBM> = DBM & {
   __compressed?: Buffer
-  __chunked?: boolean
   __chunks?: number
+}
+
+/**
+ * Shape of a row in the chunks table.
+ */
+interface ChunkRow {
+  id: string
+  primaryId: string
+  chunkIdx: number
+  __compressed: Buffer
 }


### PR DESCRIPTION
Adds `compress.chunk: true`. Splits oversized compressed payloads across a dedicated `${table}__chunks` kind. Primary row stays in the user's table with `__chunks: N`. Chunk rows carry `{ id, primaryId, chunkIdx, __compressed }`.

**Save:** write primary + chunks in parallel. Then `runQueryCount(primaryId)` → delete exact stale range.

**Read:** `getById` fires primary + chunks fetch in parallel. Queries fetch primaries, then one `filterIn('primaryId', primaryIds)` on the chunks table. Reassembly is driven by primary's `__chunks`, not config — legacy data reads correctly after turning the feature off.

**Stream:** primaries flow from the user's table; per row, if `__chunks > 1`, async-fetch that entity's chunks.

**Caveats:** chunks run outside transactions; don't name a table ending in `__chunks`; hard cap 100 chunks/entity.