### PR TITLE
feat: keepalive in fetcher

### DIFF
--- a/packages/js-lib/src/http/fetcher.model.ts
+++ b/packages/js-lib/src/http/fetcher.model.ts
@@ -263,6 +263,13 @@ export interface FetcherOptions {
    */
   redirect?: RequestRedirect
 
+  /**
+   * Default to false.
+   * When set to true, the request will not be aborted when the page is unloaded.
+   * Useful for sending analytics or tracking events that need to complete even if the user navigates away.
+   */
+  keepalive?: boolean
+
   // Removing RequestInit from options to simplify FetcherOptions interface.
   // Will instead only add hand-picked useful options, such as `credentials`.
   // init?: Partial<RequestInitNormalized>
@@ -361,6 +368,7 @@ export type RequestInitNormalized = Omit<RequestInit, 'method' | 'headers'> & {
   method: HttpMethod
   headers: Record<string, any>
   dispatcher?: Dispatcher
+  keepalive?: boolean
 }
 
 export interface FetcherSuccessResponse<BODY = unknown> {

--- a/packages/js-lib/src/http/fetcher.test.ts
+++ b/packages/js-lib/src/http/fetcher.test.ts
@@ -40,6 +40,7 @@ test('defaults', () => {
         "headers": {
           "user-agent": "fetcher/4",
         },
+        "keepalive": undefined,
         "method": "GET",
         "redirect": undefined,
       },
@@ -86,6 +87,7 @@ test('defaults', () => {
           "accept": "application/json",
           "user-agent": "fetcher/4",
         },
+        "keepalive": undefined,
         "method": "GET",
         "redirect": "follow",
       },

--- a/packages/js-lib/src/http/fetcher.ts
+++ b/packages/js-lib/src/http/fetcher.ts
@@ -744,12 +744,13 @@ export class Fetcher {
           credentials: cfg.credentials,
           redirect: cfg.redirect,
           dispatcher: cfg.dispatcher,
+          keepalive: cfg.keepalive,
         },
         hooks: {},
         throwHttpErrors: true,
         errorData: {},
       },
-      _omit(cfg, ['method', 'credentials', 'headers', 'redirect', 'logger', 'name']),
+      _omit(cfg, ['method', 'credentials', 'headers', 'redirect', 'logger', 'name', 'keepalive']),
     )
 
     norm.init.headers = _mapKeys(norm.init.headers, k => k.toLowerCase())
@@ -804,6 +805,7 @@ export class Fetcher {
           method: opt.method || this.cfg.init.method,
           credentials: opt.credentials || this.cfg.init.credentials,
           redirect: opt.redirect || this.cfg.init.redirect || 'follow',
+          keepalive: opt.keepalive ?? this.cfg.init.keepalive,
         },
         {
           headers: _mapKeys(opt.headers || {}, k => k.toLowerCase()),


### PR DESCRIPTION
could make http requests more reliable
to quote:

> This enables a [fetch()](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch) request to, for example, send analytics at the end of a session even if the user navigates away from or closes the page. This has some advantages over using [Navigator.sendBeacon()](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon) for the same purpose, including allowing you to use HTTP methods other than [POST](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods/POST), customize request properties, and access the server response via the fetch [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) fulfillment. It is also available in [service workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API).

/ https://developer.mozilla.org/en-US/docs/Web/API/Request/keepalive