### PR TITLE
chore: generate test reports in JSON format

### DIFF
--- a/packages/dev-lib/cfg/vitest.config.js
+++ b/packages/dev-lib/cfg/vitest.config.js
@@ -93,7 +93,12 @@ export function getSharedConfig(cwd) {
     exclude,
     reporters: getReporters(junitReporterEnabled, testType),
     // outputFile location is specified for compatibility with the previous jest config
-    outputFile: junitReporterEnabled ? `./tmp/jest/${testType}.xml` : undefined,
+    outputFile: junitReporterEnabled
+      ? {
+          junit: `./tmp/jest/${testType}.xml`,
+          json: `./tmp/jest/${testType}.json`,
+        }
+      : undefined,
     coverage: {
       enabled: coverageEnabled,
       reporter: ['html', 'lcov', 'json', 'json-summary', !isCI && 'text'].filter(Boolean),
@@ -136,6 +141,7 @@ function getReporters(junitReporterEnabled, testType) {
     'default',
     GITHUB_ACTIONS && 'github-actions',
     new SummaryReporter(),
+    junitReporterEnabled && 'json',
     junitReporterEnabled && [
       'junit',
       {


### PR DESCRIPTION
We generate test reports in `XML` format.

With this change, we will generate in `JSON` format as well, but keeping `XML` - not to break existing CI jobs.