### PR TITLE
feat: export commitlint function

### DIFF
--- a/packages/dev-lib/src/bin/dev-lib.ts
+++ b/packages/dev-lib/src/bin/dev-lib.ts
@@ -17,7 +17,7 @@ import {
   typecheckWithTSC,
   typecheckWithTSGO,
 } from '../check.util.js'
-import { runCommitlint } from '../commitlint.js'
+import { runCommitlint } from '../commitlint.command.js'
 
 interface Command {
   name: string

--- a/packages/dev-lib/src/commitlint.command.ts
+++ b/packages/dev-lib/src/commitlint.command.ts
@@ -1,0 +1,41 @@
+import { _assert } from '@naturalcycles/js-lib/error'
+import { fs2 } from '@naturalcycles/nodejs-lib/fs2'
+import { validateCommitMessage } from './commitlint.util.js'
+import { readDevLibConfigIfPresent } from './config.js'
+
+/**
+ * Validates the commit message,
+ * which is read from a file, passed as process.argv.at(-1)
+ */
+export async function runCommitlint(): Promise<void> {
+  //  || '.git/COMMIT_EDITMSG' // fallback is unnecessary, first argument should be always present
+  const arg1 = process.argv.at(-1)
+  _assert(arg1, 'dev-lib commitlint2 is called with $1 (first argument) missing')
+  console.log({ arg1 })
+
+  fs2.requireFileToExist(arg1)
+  const msg = fs2.readText(arg1)
+  console.log({ msg })
+
+  // Skip validation for merge commits (MERGE_HEAD exists during merge)
+  if (fs2.pathExists('.git/MERGE_HEAD')) {
+    console.log('✓ Merge commit - skipping validation')
+    return
+  }
+
+  const devLibCfg = await readDevLibConfigIfPresent()
+  console.log({ devLibCfg })
+
+  const { valid, errors } = validateCommitMessage(msg, devLibCfg.commitlint)
+
+  if (valid) {
+    console.log('✓ Valid commit message')
+    return
+  }
+
+  console.error('✗ Invalid commit message:')
+  for (const err of errors) {
+    console.error(`  - ${err}`)
+  }
+  process.exit(1)
+}

--- a/packages/dev-lib/src/commitlint.test.ts
+++ b/packages/dev-lib/src/commitlint.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { validateCommitMessage } from './commitlint.js'
+import { validateCommitMessage } from './commitlint.util.js'
 
 // Valid messages
 test('valid: simple message', () => {

--- a/packages/dev-lib/src/commitlint.util.ts
+++ b/packages/dev-lib/src/commitlint.util.ts
@@ -1,6 +1,3 @@
-import { _assert } from '@naturalcycles/js-lib/error'
-import { fs2 } from '@naturalcycles/nodejs-lib/fs2'
-import { readDevLibConfigIfPresent } from './config.js'
 import type { DevLibCommitlintConfig } from './config.js'
 
 const ALLOWED_TYPES = new Set([
@@ -18,43 +15,6 @@ const ALLOWED_TYPES = new Set([
 ])
 
 const SUBJECT_MAX_LENGTH = 120 // Only applies to subject line (first line)
-
-/**
- * Validates the commit message,
- * which is read from a file, passed as process.argv.at(-1)
- */
-export async function runCommitlint(): Promise<void> {
-  //  || '.git/COMMIT_EDITMSG' // fallback is unnecessary, first argument should be always present
-  const arg1 = process.argv.at(-1)
-  _assert(arg1, 'dev-lib commitlint2 is called with $1 (first argument) missing')
-  console.log({ arg1 })
-
-  fs2.requireFileToExist(arg1)
-  const msg = fs2.readText(arg1)
-  console.log({ msg })
-
-  // Skip validation for merge commits (MERGE_HEAD exists during merge)
-  if (fs2.pathExists('.git/MERGE_HEAD')) {
-    console.log('✓ Merge commit - skipping validation')
-    return
-  }
-
-  const devLibCfg = await readDevLibConfigIfPresent()
-  console.log({ devLibCfg })
-
-  const { valid, errors } = validateCommitMessage(msg, devLibCfg.commitlint)
-
-  if (valid) {
-    console.log('✓ Valid commit message')
-    return
-  }
-
-  console.error('✗ Invalid commit message:')
-  for (const err of errors) {
-    console.error(`  - ${err}`)
-  }
-  process.exit(1)
-}
 
 /**
  * Commit message validator following Conventional Commits specification.

--- a/packages/dev-lib/src/index.ts
+++ b/packages/dev-lib/src/index.ts
@@ -1,1 +1,2 @@
 export * from './config.js'
+export * from './commitlint.util.js'


### PR DESCRIPTION
I'd like to use `validateCommitMessage` elsewhere. Separating commitlint into `.util` and `.command` to be able to export `.util` seemed most in-pattern