### PR TITLE
feat: add roomy warning to CommonDao

### DIFF
--- a/packages/db-lib/src/commondao/common.dao.model.ts
+++ b/packages/db-lib/src/commondao/common.dao.model.ts
@@ -68,6 +68,15 @@ export interface CommonDaoHooks<
   beforeSave?: (dbm: DBM) => void
 
   /**
+   * Invoked when the `__compressed` Buffer for a row exceeds the
+   * `compress.warnSizeBytes` threshold. No-op unless both `compress.warnSizeBytes`
+   * is set and this hook is provided.
+   *
+   * Consumer decides how to surface the warning (Sentry, logger, metrics, etc.).
+   */
+  onOversizeWarning?: (info: { table: string; id: string; size: number; threshold: number }) => void
+
+  /**
    * If hook is defined - allows to prevent or modify the error thrown.
    * Return `false` to prevent throwing an error.
    * Return original `err` to pass the error through (will be thrown in CommonDao).
@@ -224,6 +233,14 @@ export interface CommonDaoCfg<
      * Undefined will default to level 1 (not the 3, which is the zstd default)
      */
     level?: Integer
+    /**
+     * If set, the `onOversizeWarning` hook is invoked whenever the resulting
+     * `__compressed` Buffer exceeds this size in bytes. Useful for monitoring
+     * rows approaching DB row-size limits (e.g. Datastore's 1MB per entity).
+     *
+     * No-op unless `hooks.onOversizeWarning` is also provided.
+     */
+    warnSizeBytes?: number
   }
 }
 

--- a/packages/db-lib/src/commondao/common.dao.model.ts
+++ b/packages/db-lib/src/commondao/common.dao.model.ts
@@ -68,15 +68,6 @@ export interface CommonDaoHooks<
   beforeSave?: (dbm: DBM) => void
 
   /**
-   * Invoked when the `__compressed` Buffer for a row exceeds the
-   * `compress.warnSizeBytes` threshold. No-op unless both `compress.warnSizeBytes`
-   * is set and this hook is provided.
-   *
-   * Consumer decides how to surface the warning (Sentry, logger, metrics, etc.).
-   */
-  onOversizeWarning?: (info: { table: string; id: string; size: number; threshold: number }) => void
-
-  /**
    * If hook is defined - allows to prevent or modify the error thrown.
    * Return `false` to prevent throwing an error.
    * Return original `err` to pass the error through (will be thrown in CommonDao).
@@ -234,13 +225,21 @@ export interface CommonDaoCfg<
      */
     level?: Integer
     /**
-     * If set, the `onOversizeWarning` hook is invoked whenever the resulting
-     * `__compressed` Buffer exceeds this size in bytes. Useful for monitoring
-     * rows approaching DB row-size limits (e.g. Datastore's 1MB per entity).
+     * If set, `onOversizeWarning` is invoked whenever the resulting `__compressed`
+     * Buffer exceeds this size in bytes. Useful for monitoring rows approaching
+     * DB row-size limits (e.g. Datastore's 1MB per entity).
      *
-     * No-op unless `hooks.onOversizeWarning` is also provided.
+     * No-op unless `onOversizeWarning` is also provided.
      */
     warnSizeBytes?: number
+    /**
+     * Invoked when the `__compressed` Buffer exceeds `warnSizeBytes`.
+     *
+     * Called with a shallow clone of the DBM (since the original is mutated
+     * later in the compression step) and the resulting compressed size in bytes.
+     * The consumer decides how to surface the warning (Sentry, logger, metrics, etc.).
+     */
+    onOversizeWarning?: (dbm: DBM, size: number) => void
   }
 }
 

--- a/packages/db-lib/src/commondao/common.dao.test.ts
+++ b/packages/db-lib/src/commondao/common.dao.test.ts
@@ -1276,7 +1276,7 @@ describe('auto compression', () => {
 
   describe('warnSizeBytes', () => {
     type OnOversizeWarning = NonNullable<
-      NonNullable<CommonDaoCfg<Item>['hooks']>['onOversizeWarning']
+      NonNullable<CommonDaoCfg<Item>['compress']>['onOversizeWarning']
     >
 
     test('fires onOversizeWarning when compressed payload exceeds threshold', async () => {
@@ -1287,20 +1287,42 @@ describe('auto compression', () => {
         compress: {
           keys: ['obj', 'shu'],
           warnSizeBytes: 1,
+          onOversizeWarning,
         },
-        hooks: { onOversizeWarning },
       })
 
       await dao.save({ id: 'id1', obj: { objId: 'objId1' }, shu: 'shu1' })
 
       expect(onOversizeWarning).toHaveBeenCalledTimes(1)
-      expect(onOversizeWarning).toHaveBeenCalledWith({
-        table: TEST_TABLE,
+      const [dbm, size] = onOversizeWarning.mock.calls[0]!
+      expect(dbm).toMatchObject({
         id: 'id1',
-        size: expect.any(Number),
-        threshold: 1,
+        obj: { objId: 'objId1' },
+        shu: 'shu1',
       })
-      expect(onOversizeWarning.mock.calls[0]![0].size).toBeGreaterThan(1)
+      // hook receives pre-mutation snapshot (no __compressed yet, source keys still present)
+      expect(dbm).not.toHaveProperty('__compressed')
+      expect(size).toBeGreaterThan(1)
+    })
+
+    test('hook receives a clone, not a reference to the mutated dbm', async () => {
+      let capturedDbm: Item | undefined
+      const dao = new CommonDao<Item>({
+        table: TEST_TABLE,
+        db,
+        compress: {
+          keys: ['obj', 'shu'],
+          warnSizeBytes: 1,
+          onOversizeWarning: dbm => {
+            capturedDbm = dbm
+          },
+        },
+      })
+
+      await dao.save({ id: 'id1', obj: { objId: 'objId1' }, shu: 'shu1' })
+
+      expect(capturedDbm).toMatchObject({ obj: { objId: 'objId1' }, shu: 'shu1' })
+      expect(capturedDbm).not.toHaveProperty('__compressed')
     })
 
     test('does not fire when compressed payload is under threshold', async () => {
@@ -1311,8 +1333,8 @@ describe('auto compression', () => {
         compress: {
           keys: ['obj', 'shu'],
           warnSizeBytes: 1_000_000,
+          onOversizeWarning,
         },
-        hooks: { onOversizeWarning },
       })
 
       await dao.save({ id: 'id1', obj: { objId: 'objId1' }, shu: 'shu1' })

--- a/packages/db-lib/src/commondao/common.dao.test.ts
+++ b/packages/db-lib/src/commondao/common.dao.test.ts
@@ -1273,4 +1273,51 @@ describe('auto compression', () => {
 
     saveBatchSpy.mockRestore()
   })
+
+  describe('warnSizeBytes', () => {
+    type OnOversizeWarning = NonNullable<
+      NonNullable<CommonDaoCfg<Item>['hooks']>['onOversizeWarning']
+    >
+
+    test('fires onOversizeWarning when compressed payload exceeds threshold', async () => {
+      const onOversizeWarning = vi.fn<OnOversizeWarning>()
+      const dao = new CommonDao<Item>({
+        table: TEST_TABLE,
+        db,
+        compress: {
+          keys: ['obj', 'shu'],
+          warnSizeBytes: 1,
+        },
+        hooks: { onOversizeWarning },
+      })
+
+      await dao.save({ id: 'id1', obj: { objId: 'objId1' }, shu: 'shu1' })
+
+      expect(onOversizeWarning).toHaveBeenCalledTimes(1)
+      expect(onOversizeWarning).toHaveBeenCalledWith({
+        table: TEST_TABLE,
+        id: 'id1',
+        size: expect.any(Number),
+        threshold: 1,
+      })
+      expect(onOversizeWarning.mock.calls[0]![0].size).toBeGreaterThan(1)
+    })
+
+    test('does not fire when compressed payload is under threshold', async () => {
+      const onOversizeWarning = vi.fn<OnOversizeWarning>()
+      const dao = new CommonDao<Item>({
+        table: TEST_TABLE,
+        db,
+        compress: {
+          keys: ['obj', 'shu'],
+          warnSizeBytes: 1_000_000,
+        },
+        hooks: { onOversizeWarning },
+      })
+
+      await dao.save({ id: 'id1', obj: { objId: 'objId1' }, shu: 'shu1' })
+
+      expect(onOversizeWarning).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/db-lib/src/commondao/common.dao.ts
+++ b/packages/db-lib/src/commondao/common.dao.ts
@@ -849,19 +849,16 @@ export class CommonDao<
   private async compress(dbm: DBM): Promise<void> {
     if (!this.cfg.compress?.keys.length) return // No compression requested
 
-    const { keys, level = 1, warnSizeBytes } = this.cfg.compress
+    const { keys, level = 1, warnSizeBytes, onOversizeWarning } = this.cfg.compress
     const properties = _pick(dbm, keys)
     const bufferString = JSON.stringify(properties)
     // Unlike `decompress`, we're testing to use async zstd compression.
     // Async Decompression leaks memory severely. But Compression seems fine.
     const __compressed = await zip2.zstdCompress(bufferString, level)
-    if (warnSizeBytes && __compressed.byteLength > warnSizeBytes) {
-      this.cfg.hooks?.onOversizeWarning?.({
-        table: this.cfg.table,
-        id: dbm.id,
-        size: __compressed.byteLength,
-        threshold: warnSizeBytes,
-      })
+    if (warnSizeBytes && onOversizeWarning && __compressed.byteLength > warnSizeBytes) {
+      // Shallow-clone: `dbm` is mutated below (omit source keys + assign __compressed),
+      // so we hand the hook a snapshot of the pre-mutation state.
+      onOversizeWarning({ ...dbm }, __compressed.byteLength)
     }
     _omitWithUndefined(dbm as any, _objectKeys(properties), { mutate: true })
     Object.assign(dbm, { __compressed })

--- a/packages/db-lib/src/commondao/common.dao.ts
+++ b/packages/db-lib/src/commondao/common.dao.ts
@@ -849,12 +849,20 @@ export class CommonDao<
   private async compress(dbm: DBM): Promise<void> {
     if (!this.cfg.compress?.keys.length) return // No compression requested
 
-    const { keys, level = 1 } = this.cfg.compress
+    const { keys, level = 1, warnSizeBytes } = this.cfg.compress
     const properties = _pick(dbm, keys)
     const bufferString = JSON.stringify(properties)
     // Unlike `decompress`, we're testing to use async zstd compression.
     // Async Decompression leaks memory severely. But Compression seems fine.
     const __compressed = await zip2.zstdCompress(bufferString, level)
+    if (warnSizeBytes && __compressed.byteLength > warnSizeBytes) {
+      this.cfg.hooks?.onOversizeWarning?.({
+        table: this.cfg.table,
+        id: dbm.id,
+        size: __compressed.byteLength,
+        threshold: warnSizeBytes,
+      })
+    }
     _omitWithUndefined(dbm as any, _objectKeys(properties), { mutate: true })
     Object.assign(dbm, { __compressed })
   }


### PR DESCRIPTION
In this PR, I add oversize warning a la David to CommonDao.

A `warnSizeBytes` can be set under the `compress` config -> since we only check compressed rows.
(Why not a default size? Meh...)

Reports via `onOversizeWarning` hook.
Idea: Put it in NCCommonDao, not into individual Daos.