### PR TITLE
feat(abba): add getUserIdsInBuckets method

### DIFF
--- a/packages/abba/src/abba.test.ts
+++ b/packages/abba/src/abba.test.ts
@@ -460,6 +460,46 @@ describe('getAllExperimentsWithUserAssignments', () => {
   })
 })
 
+describe('getUserIdsInBuckets', () => {
+  test('returns empty Set when experiment key does not exist', async () => {
+    const result = await abba.getUserIdsInBuckets('nonexistent_key', ['control'])
+    expect(result).toEqual(new Set())
+  })
+
+  test('returns empty Set when none of the bucket keys match', async () => {
+    const experiment = await experimentsDAO.save(mockExperiment({ key: 'exp_bucket_test' }))
+    await bucketsDAO.save(mockBucket(experiment.id, 'control', 100))
+
+    const result = await abba.getUserIdsInBuckets('exp_bucket_test', ['treatment'])
+    expect(result).toEqual(new Set())
+  })
+
+  test('returns correct user IDs when matching assignments exist', async () => {
+    const experiment = await experimentsDAO.save(mockExperiment({ key: 'exp_user_ids' }))
+    const bucket = await bucketsDAO.save(mockBucket(experiment.id, 'treatment', 100))
+    await userAssignmentsDAO.save(mockUserAssignment(experiment.id, bucket.id, { userId: 'user1' }))
+    await userAssignmentsDAO.save(mockUserAssignment(experiment.id, bucket.id, { userId: 'user2' }))
+
+    const result = await abba.getUserIdsInBuckets('exp_user_ids', ['treatment'])
+    expect(result).toEqual(new Set(['user1', 'user2']))
+  })
+
+  test('deduplicates user IDs when a user is assigned to multiple matching buckets', async () => {
+    const experiment = await experimentsDAO.save(mockExperiment({ key: 'exp_dedup' }))
+    const bucket1 = await bucketsDAO.save(mockBucket(experiment.id, 'bucketA', 50))
+    const bucket2 = await bucketsDAO.save(mockBucket(experiment.id, 'bucketB', 50))
+    await userAssignmentsDAO.save(
+      mockUserAssignment(experiment.id, bucket1.id, { userId: 'sharedUser' }),
+    )
+    await userAssignmentsDAO.save(
+      mockUserAssignment(experiment.id, bucket2.id, { userId: 'sharedUser' }),
+    )
+
+    const result = await abba.getUserIdsInBuckets('exp_dedup', ['bucketA', 'bucketB'])
+    expect(result).toEqual(new Set(['sharedUser']))
+  })
+})
+
 describe('softDeleteExperiment', () => {
   test('should soft delete an experiment', async () => {
     const experiment = await experimentsDAO.save(

--- a/packages/abba/src/abba.ts
+++ b/packages/abba/src/abba.ts
@@ -412,6 +412,31 @@ export class Abba {
   }
 
   /**
+   * Returns all user IDs that are assigned to any of the given buckets in the given experiment.
+   *
+   * @param experimentKey - The `key` field of the experiment (not the DB id).
+   * @param bucketKeys - The `key` fields of the buckets to include.
+   */
+  async getUserIdsInBuckets(
+    experimentKey: string,
+    bucketKeys: readonly string[],
+  ): Promise<Set<string>> {
+    if (!bucketKeys.length) return new Set()
+
+    const experiment = await this.experimentDao.getByKey(experimentKey)
+    if (!experiment) return new Set()
+
+    const bucketKeySet = new Set(bucketKeys)
+    const experimentBuckets = await this.bucketDao.getByExperimentId(experiment.id)
+    const matchedBucketIds = experimentBuckets.filter(b => bucketKeySet.has(b.key)).map(b => b.id)
+
+    if (!matchedBucketIds.length) return new Set()
+
+    const userIds = await this.userAssignmentDao.getUserIdsByBucketIds(matchedBucketIds)
+    return new Set(userIds)
+  }
+
+  /**
    * Get assignment statistics for an experiment.
    * Cold method.
    */

--- a/packages/abba/src/dao/userAssignment.dao.ts
+++ b/packages/abba/src/dao/userAssignment.dao.ts
@@ -31,6 +31,18 @@ export class UserAssignmentDao extends CommonDao<UserAssignment> {
   async getCountByBucketId(bucketId: string): Promise<number> {
     return await this.query().filterEq('bucketId', bucketId).runQueryCount()
   }
+
+  async getUserIdsByBucketIds(bucketIds: string[]): Promise<string[]> {
+    if (!bucketIds.length) return []
+
+    const userIds = await this.query()
+      .filterIn('bucketId', bucketIds)
+      .select(['userId'])
+      .distinct()
+      .runQuerySingleColumn<string>()
+
+    return Array.from(new Set(userIds))
+  }
 }
 
 export function userAssignmentDao(db: CommonDB): UserAssignmentDao {

--- a/packages/abba/src/dao/userAssignment.dao.ts
+++ b/packages/abba/src/dao/userAssignment.dao.ts
@@ -1,5 +1,6 @@
 import type { CommonDB } from '@naturalcycles/db-lib'
 import { CommonDao } from '@naturalcycles/db-lib/dao'
+import { _uniq } from '@naturalcycles/js-lib/array'
 import type { UserAssignment } from '../types.js'
 
 export class UserAssignmentDao extends CommonDao<UserAssignment> {
@@ -41,7 +42,7 @@ export class UserAssignmentDao extends CommonDao<UserAssignment> {
       .distinct()
       .runQuerySingleColumn<string>()
 
-    return Array.from(new Set(userIds))
+    return _uniq(userIds)
   }
 }
 


### PR DESCRIPTION
Adds `Abba.getUserIdsInBuckets(experimentKey, bucketKeys)` so if A/B gating a reminder, we can retrieve users assigned to specific experiment buckets, rather than querying user-by-user.

[Related to this PR](https://github.com/NaturalCycles/NCBackend3/pull/13496)