### PR TITLE
feat: typesafe excludefromindexes

### DIFF
--- a/packages/airtable-lib/src/query.util.ts
+++ b/packages/airtable-lib/src/query.util.ts
@@ -21,7 +21,7 @@ export function dbQueryToAirtableSelectOptions<ROW extends ObjectWithId>(
   if (q._filters.length) {
     const tokens = q._filters.map(f => {
       if (f.op === 'in') {
-        const pairs = (f.val as any[]).map(v => `{${f.name as string}}="${v}"`)
+        const pairs = (f.val as any[]).map(v => `{${f.name}}="${v}"`)
         return `OR(${pairs.join(',')})`
       }
 
@@ -30,7 +30,7 @@ export function dbQueryToAirtableSelectOptions<ROW extends ObjectWithId>(
         if (f.val) {
           v = 'TRUE()'
         } else {
-          return `OR({${String(f.name)}}=FALSE(),{${String(f.name)}}=BLANK())`
+          return `OR({${f.name}}=FALSE(),{${f.name}}=BLANK())`
         }
       } else {
         v = `"${f.val}"`
@@ -38,7 +38,7 @@ export function dbQueryToAirtableSelectOptions<ROW extends ObjectWithId>(
 
       const op = OP_MAP[f.op] || f.op
 
-      return `{${String(f.name)}}${op}${v}`
+      return `{${f.name}}${op}${v}`
     })
 
     o.filterByFormula = `AND(${tokens.join(',')})`

--- a/packages/datastore-lib/src/query.util.ts
+++ b/packages/datastore-lib/src/query.util.ts
@@ -35,7 +35,7 @@ export function dbQueryToDatastoreQuery<ROW extends ObjectWithId>(
     // `a == null` will return just that - rows with null values
     let { op, val } = f
     if (val === undefined) val = null
-    q = q.filter(new PropertyFilter(f.name as string, OP_MAP[op] || (op as any), val))
+    q = q.filter(new PropertyFilter(f.name, OP_MAP[op] || (op as any), val))
   }
 
   // limit
@@ -43,7 +43,7 @@ export function dbQueryToDatastoreQuery<ROW extends ObjectWithId>(
 
   // order
   for (const ord of dbQuery._orders) {
-    q = q.order(ord.name as string, { descending: ord.descending })
+    q = q.order(ord.name, { descending: ord.descending })
   }
 
   // select

--- a/packages/db-lib/src/commondao/common.dao.model.ts
+++ b/packages/db-lib/src/commondao/common.dao.model.ts
@@ -429,8 +429,8 @@ export type CommonDaoCreateOptions = CommonDBCreateOptions
 /**
  * Legacy array form for `CommonDaoCfg.excludeFromIndexes`.
  *
- * @deprecated Use the function form: `excludeFromIndexes: ex => [...]`. The function
- * form receives a typed `ExcludeBuilder` directly, so you don't have to construct one
- * yourself with `createExcludeBuilder<DBM>()`.
+ * @deprecated Use the function form: `excludeFromIndexes: ex => [...]`. The function form
+ * receives a typed `ExcludeFromIndexesBuilder` as `ex`, giving access to the
+ * `.object(...)` / `.array(...)` / `.property(...)` / `.wildcard()` chain.
  */
 export type LegacyExcludeFromIndexesArray<DBM extends BaseDBEntity> = ExcludePathSpec<DBM>[]

--- a/packages/db-lib/src/commondao/common.dao.model.ts
+++ b/packages/db-lib/src/commondao/common.dao.model.ts
@@ -5,6 +5,7 @@ import type { BaseDBEntity, Integer, UnixTimestamp } from '@naturalcycles/js-lib
 import type { TransformLogProgressOptions } from '@naturalcycles/nodejs-lib/stream'
 import type { CommonDB } from '../commondb/common.db.js'
 import type { CommonDBCreateOptions, CommonDBOptions, CommonDBSaveOptions } from '../db.model.js'
+import type { ExcludeBuilder, ExcludePathSpec } from './excludePath.js'
 
 export interface CommonDaoHooks<
   BM extends BaseDBEntity,
@@ -112,9 +113,22 @@ export interface CommonDaoCfg<
   validateBM?: ValidationFunction<BM, any>
 
   /**
+   * Fields to exclude from indexing. Prefer the builder function form below for
+   * type-safe nested, wildcard, and array-element paths.
+   *
    * Used by e.g Datastore.
+   *
+   * @example
+   *   excludeFromIndexes: ex => [
+   *     'title',
+   *     ex.nested('meta', 'author'),
+   *     ex.wildcard('config'),
+   *     ex.element('tags'),
+   *   ]
    */
-  excludeFromIndexes?: (keyof DBM)[]
+  excludeFromIndexes?:
+    | LegacyExcludeFromIndexesArray<DBM>
+    | ((ex: ExcludeBuilder<DBM>) => ExcludePathSpec<DBM>[])
 
   /**
    * Used by e.g Firestore.
@@ -410,3 +424,12 @@ export interface CommonDaoStreamOptions<IN>
 }
 
 export type CommonDaoCreateOptions = CommonDBCreateOptions
+
+/**
+ * Legacy array form for `CommonDaoCfg.excludeFromIndexes`.
+ *
+ * @deprecated Use the builder function form instead: `excludeFromIndexes: ex => [...]`.
+ * It is more type-safe (nested paths, wildcards, array elements all checked against
+ * the row type) and is the preferred shape going forward.
+ */
+export type LegacyExcludeFromIndexesArray<DBM extends BaseDBEntity> = ExcludePathSpec<DBM>[]

--- a/packages/db-lib/src/commondao/common.dao.model.ts
+++ b/packages/db-lib/src/commondao/common.dao.model.ts
@@ -5,7 +5,7 @@ import type { BaseDBEntity, Integer, UnixTimestamp } from '@naturalcycles/js-lib
 import type { TransformLogProgressOptions } from '@naturalcycles/nodejs-lib/stream'
 import type { CommonDB } from '../commondb/common.db.js'
 import type { CommonDBCreateOptions, CommonDBOptions, CommonDBSaveOptions } from '../db.model.js'
-import type { ExcludeBuilder, ExcludePathSpec } from './excludePath.js'
+import type { ExcludeFromIndexesBuilder, ExcludePathSpec } from './excludePath.js'
 
 export interface CommonDaoHooks<
   BM extends BaseDBEntity,
@@ -121,14 +121,15 @@ export interface CommonDaoCfg<
    * @example
    *   excludeFromIndexes: ex => [
    *     'title',
-   *     ex.nested('meta', 'author'),
-   *     ex.wildcard('config'),
-   *     ex.element('tags'),
+   *     ex.object('meta').property('author'),    // 'meta.author'
+   *     ex.object('config').wildcard(),          // 'config.*'
+   *     ex.array('tags').wildcard(),             // 'tags[].*'
+   *     ex.array('tags').property('score'),      // 'tags[].score'
    *   ]
    */
   excludeFromIndexes?:
     | LegacyExcludeFromIndexesArray<DBM>
-    | ((ex: ExcludeBuilder<DBM>) => ExcludePathSpec<DBM>[])
+    | ((ex: ExcludeFromIndexesBuilder<DBM>) => ExcludePathSpec<DBM>[])
 
   /**
    * Used by e.g Firestore.
@@ -428,8 +429,8 @@ export type CommonDaoCreateOptions = CommonDBCreateOptions
 /**
  * Legacy array form for `CommonDaoCfg.excludeFromIndexes`.
  *
- * @deprecated Use the builder function form instead: `excludeFromIndexes: ex => [...]`.
- * It is more type-safe (nested paths, wildcards, array elements all checked against
- * the row type) and is the preferred shape going forward.
+ * @deprecated Use the function form: `excludeFromIndexes: ex => [...]`. The function
+ * form receives a typed `ExcludeBuilder` directly, so you don't have to construct one
+ * yourself with `createExcludeBuilder<DBM>()`.
  */
 export type LegacyExcludeFromIndexesArray<DBM extends BaseDBEntity> = ExcludePathSpec<DBM>[]

--- a/packages/db-lib/src/commondao/common.dao.test.ts
+++ b/packages/db-lib/src/commondao/common.dao.test.ts
@@ -1359,10 +1359,10 @@ describe('excludeFromIndexes builder', () => {
       db,
       excludeFromIndexes: ex => [
         'name',
-        ex.nested('nested', 'foo'),
-        ex.wildcard('config'),
-        ex.element('tags'),
-        ex.element('tags', 'score'),
+        ex.object('nested').property('foo'),
+        ex.object('config').wildcard(),
+        ex.array('tags').wildcard(),
+        ex.array('tags').property('score'),
       ],
     })
 
@@ -1414,7 +1414,7 @@ describe('excludeFromIndexes builder', () => {
       table: TEST_TABLE_2,
       db,
       compress: { keys: ['nested'] },
-      excludeFromIndexes: ex => [ex.nested('nested', 'foo')],
+      excludeFromIndexes: ex => [ex.object('nested').property('foo')],
     })
 
     const saveBatchSpy = vi.spyOn(db, 'saveBatch')

--- a/packages/db-lib/src/commondao/common.dao.test.ts
+++ b/packages/db-lib/src/commondao/common.dao.test.ts
@@ -733,7 +733,7 @@ test('should not be able to query by a non-indexed property', async () => {
   const dao = new CommonDao<TestItemBM>({
     table: TEST_TABLE,
     db,
-    excludeFromIndexes: ['k1'],
+    excludeFromIndexes: () => ['k1'],
   })
 
   await dao.saveBatch(createTestItemsBM(5))
@@ -1341,5 +1341,94 @@ describe('auto compression', () => {
 
       expect(onOversizeWarning).not.toHaveBeenCalled()
     })
+  })
+})
+
+describe('excludeFromIndexes builder', () => {
+  interface NestedItem extends BaseDBEntity {
+    name: string
+    nested?: { foo: number; bar: string }
+    config?: { theme: string }
+    tags?: { label: string; score: number }[]
+  }
+
+  test('should compile builder specs to strings passed to db.saveBatch', async () => {
+    const db = new InMemoryDB()
+    const dao = new CommonDao<NestedItem>({
+      table: TEST_TABLE_2,
+      db,
+      excludeFromIndexes: ex => [
+        'name',
+        ex.nested('nested', 'foo'),
+        ex.wildcard('config'),
+        ex.element('tags'),
+        ex.element('tags', 'score'),
+      ],
+    })
+
+    const saveBatchSpy = vi.spyOn(db, 'saveBatch')
+
+    await dao.saveBatch([{ id: 'id1', name: 'a' }])
+
+    expect(saveBatchSpy).toHaveBeenCalledWith(
+      TEST_TABLE_2,
+      expect.any(Array),
+      expect.objectContaining({
+        excludeFromIndexes: ['name', 'nested.foo', 'config.*', 'tags[].*', 'tags[].score'],
+      }),
+    )
+
+    saveBatchSpy.mockRestore()
+  })
+
+  test('should accept the plain array form of excludeFromIndexes', async () => {
+    const db = new InMemoryDB()
+    const dao = new CommonDao<NestedItem>({
+      table: TEST_TABLE_2,
+      db,
+      excludeFromIndexes: [
+        'name',
+        // builder helpers may still be used inline if desired, but plain string keys
+        // are the most common case for the array form:
+      ],
+    })
+
+    const saveBatchSpy = vi.spyOn(db, 'saveBatch')
+
+    await dao.saveBatch([{ id: 'id1', name: 'a' }])
+
+    expect(saveBatchSpy).toHaveBeenCalledWith(
+      TEST_TABLE_2,
+      expect.any(Array),
+      expect.objectContaining({
+        excludeFromIndexes: ['name'],
+      }),
+    )
+
+    saveBatchSpy.mockRestore()
+  })
+
+  test('should append __compressed alongside user-provided specs when compression is enabled', async () => {
+    const db = new InMemoryDB()
+    const dao = new CommonDao<NestedItem>({
+      table: TEST_TABLE_2,
+      db,
+      compress: { keys: ['nested'] },
+      excludeFromIndexes: ex => [ex.nested('nested', 'foo')],
+    })
+
+    const saveBatchSpy = vi.spyOn(db, 'saveBatch')
+
+    await dao.saveBatch([{ id: 'id1', name: 'a', nested: { foo: 1, bar: 'b' } }])
+
+    expect(saveBatchSpy).toHaveBeenCalledWith(
+      TEST_TABLE_2,
+      expect.any(Array),
+      expect.objectContaining({
+        excludeFromIndexes: expect.arrayContaining(['nested.foo', '__compressed']),
+      }),
+    )
+
+    saveBatchSpy.mockRestore()
   })
 })

--- a/packages/db-lib/src/commondao/common.dao.ts
+++ b/packages/db-lib/src/commondao/common.dao.ts
@@ -72,14 +72,6 @@ export class CommonDao<
   /** Compiled string form of `cfg.excludeFromIndexes`, populated in the constructor. */
   private compiledExcludeFromIndexes: string[] | undefined
 
-  /**
-   * Top-level keys among `compiledExcludeFromIndexes` (no `.` or `[`), used to short-circuit
-   * query validation. Only top-level excluded keys make filter-by-that-key a query that
-   * would silently return nothing; nested/wildcard/array-element exclusions leave the
-   * top-level key indexed.
-   */
-  private compiledExcludeTopLevelKeys: Set<string> | undefined
-
   constructor(public cfg: CommonDaoCfg<BM, DBM, ID>) {
     this.cfg = {
       generateId: true,
@@ -114,10 +106,6 @@ export class CommonDao<
       }
       this.compiledExcludeFromIndexes = specs.map(compileExcludePath)
     }
-
-    this.compiledExcludeTopLevelKeys = this.compiledExcludeFromIndexes
-      ? new Set(this.compiledExcludeFromIndexes.filter(s => !s.includes('.') && !s.includes('[')))
-      : undefined
 
     // If auto-compression is enabled, ensure '__compressed' is part of the exclusion list.
     if (this.cfg.compress?.keys) {
@@ -1250,12 +1238,12 @@ export class CommonDao<
    */
   private validateQueryIndexes(q: DBQuery<DBM>): void {
     const { indexes } = this.cfg
-    const excludeTopLevelKeys = this.compiledExcludeTopLevelKeys
+    const excludeFromIndexes = this.compiledExcludeFromIndexes
 
-    if (excludeTopLevelKeys) {
+    if (excludeFromIndexes) {
       for (const f of q._filters) {
         _assert(
-          !excludeTopLevelKeys.has(f.name),
+          !excludeFromIndexes.includes(f.name),
           `cannot query on non-indexed property: ${this.cfg.table}.${f.name}`,
           {
             query: q.pretty(),

--- a/packages/db-lib/src/commondao/common.dao.ts
+++ b/packages/db-lib/src/commondao/common.dao.ts
@@ -51,7 +51,7 @@ import type {
   CommonDaoStreamSaveOptions,
 } from './common.dao.model.js'
 import { CommonDaoTransaction } from './commonDaoTransaction.js'
-import { compileExcludePath, createExcludeBuilder } from './excludePath.js'
+import { compileExcludePath, ExcludeFromIndexesBuilder } from './excludePath.js'
 
 /**
  * Lowest common denominator API between supported Databases.
@@ -70,6 +70,14 @@ export class CommonDao<
 > {
   /** Compiled string form of `cfg.excludeFromIndexes`, populated in the constructor. */
   private compiledExcludeFromIndexes: string[] | undefined
+
+  /**
+   * Top-level keys among `compiledExcludeFromIndexes` (no `.` or `[`), used to short-circuit
+   * query validation. Only top-level excluded keys make filter-by-that-key a query that
+   * would silently return nothing; nested/wildcard/array-element exclusions leave the
+   * top-level key indexed.
+   */
+  private compiledExcludeTopLevelKeys: Set<string> | undefined
 
   constructor(public cfg: CommonDaoCfg<BM, DBM, ID>) {
     this.cfg = {
@@ -99,10 +107,14 @@ export class CommonDao<
     if (this.cfg.excludeFromIndexes) {
       const specs =
         typeof this.cfg.excludeFromIndexes === 'function'
-          ? this.cfg.excludeFromIndexes(createExcludeBuilder<DBM>())
+          ? this.cfg.excludeFromIndexes(new ExcludeFromIndexesBuilder<DBM>())
           : this.cfg.excludeFromIndexes
       this.compiledExcludeFromIndexes = specs.map(compileExcludePath)
     }
+
+    this.compiledExcludeTopLevelKeys = this.compiledExcludeFromIndexes
+      ? new Set(this.compiledExcludeFromIndexes.filter(s => !s.includes('.') && !s.includes('[')))
+      : undefined
 
     // If auto-compression is enabled, ensure '__compressed' is part of the exclusion list.
     if (this.cfg.compress?.keys) {
@@ -1237,12 +1249,12 @@ export class CommonDao<
    */
   private validateQueryIndexes(q: DBQuery<DBM>): void {
     const { indexes } = this.cfg
-    const excludeFromIndexes = this.compiledExcludeFromIndexes
+    const excludeTopLevelKeys = this.compiledExcludeTopLevelKeys
 
-    if (excludeFromIndexes) {
+    if (excludeTopLevelKeys) {
       for (const f of q._filters) {
         _assert(
-          !excludeFromIndexes.includes(f.name),
+          !excludeTopLevelKeys.has(f.name),
           `cannot query on non-indexed property: ${this.cfg.table}.${f.name}`,
           {
             query: q.pretty(),

--- a/packages/db-lib/src/commondao/common.dao.ts
+++ b/packages/db-lib/src/commondao/common.dao.ts
@@ -51,6 +51,7 @@ import type {
   CommonDaoStreamSaveOptions,
 } from './common.dao.model.js'
 import { CommonDaoTransaction } from './commonDaoTransaction.js'
+import { compileExcludePath, createExcludeBuilder } from './excludePath.js'
 
 /**
  * Lowest common denominator API between supported Databases.
@@ -67,6 +68,9 @@ export class CommonDao<
   DBM extends BaseDBEntity = BM,
   ID extends string = BM['id'],
 > {
+  /** Compiled string form of `cfg.excludeFromIndexes`, populated in the constructor. */
+  private compiledExcludeFromIndexes: string[] | undefined
+
   constructor(public cfg: CommonDaoCfg<BM, DBM, ID>) {
     this.cfg = {
       generateId: true,
@@ -91,13 +95,20 @@ export class CommonDao<
       delete this.cfg.hooks!.createRandomId
     }
 
-    // If the auto-compression is enabled,
-    // then we need to ensure that the '__compressed' property is part of the index exclusion list.
+    // Compile the user-provided array or builder function into a flat string[] used by the rest of the DAO.
+    if (this.cfg.excludeFromIndexes) {
+      const specs =
+        typeof this.cfg.excludeFromIndexes === 'function'
+          ? this.cfg.excludeFromIndexes(createExcludeBuilder<DBM>())
+          : this.cfg.excludeFromIndexes
+      this.compiledExcludeFromIndexes = specs.map(compileExcludePath)
+    }
+
+    // If auto-compression is enabled, ensure '__compressed' is part of the exclusion list.
     if (this.cfg.compress?.keys) {
-      const current = this.cfg.excludeFromIndexes
-      this.cfg.excludeFromIndexes = current ? current.slice() : []
-      if (!this.cfg.excludeFromIndexes.includes('__compressed' as any)) {
-        this.cfg.excludeFromIndexes.push('__compressed' as any)
+      this.compiledExcludeFromIndexes ??= []
+      if (!this.compiledExcludeFromIndexes.includes('__compressed')) {
+        this.compiledExcludeFromIndexes.push('__compressed')
       }
     }
   }
@@ -158,11 +169,20 @@ export class CommonDao<
     return this.storageRowsToDBM(rows)
   }
 
-  async getBy(by: keyof DBM, value: any, limit = 0, opt?: CommonDaoReadOptions): Promise<BM[]> {
+  async getBy(
+    by: keyof DBM & string,
+    value: any,
+    limit = 0,
+    opt?: CommonDaoReadOptions,
+  ): Promise<BM[]> {
     return await this.query().filterEq(by, value).limit(limit).runQuery(opt)
   }
 
-  async getOneBy(by: keyof DBM, value: any, opt?: CommonDaoReadOptions): Promise<BM | null> {
+  async getOneBy(
+    by: keyof DBM & string,
+    value: any,
+    opt?: CommonDaoReadOptions,
+  ): Promise<BM | null> {
     const [bm] = await this.query().filterEq(by, value).limit(1).runQuery(opt)
     return bm || null
   }
@@ -550,13 +570,13 @@ export class CommonDao<
     let {
       saveMethod,
       assignGeneratedIds = this.cfg.assignGeneratedIds,
-      excludeFromIndexes = this.cfg.excludeFromIndexes,
+      excludeFromIndexes = this.compiledExcludeFromIndexes,
     } = opt
 
-    // If the user passed in custom `excludeFromIndexes` with the save() call,
+    // If the user passed in a custom `excludeFromIndexes` with the save() call,
     // and the auto-compression is enabled,
     // then we need to ensure that the '__compressed' property is part of the list.
-    if (this.cfg.compress?.keys) {
+    if (this.cfg.compress?.keys && excludeFromIndexes !== this.compiledExcludeFromIndexes) {
       excludeFromIndexes ??= []
       if (!excludeFromIndexes.includes('__compressed' as any)) {
         excludeFromIndexes.push('__compressed' as any)
@@ -1216,13 +1236,14 @@ export class CommonDao<
    * Throws if query uses a property that is in `excludeFromIndexes` list.
    */
   private validateQueryIndexes(q: DBQuery<DBM>): void {
-    const { excludeFromIndexes, indexes } = this.cfg
+    const { indexes } = this.cfg
+    const excludeFromIndexes = this.compiledExcludeFromIndexes
 
     if (excludeFromIndexes) {
       for (const f of q._filters) {
         _assert(
           !excludeFromIndexes.includes(f.name),
-          `cannot query on non-indexed property: ${this.cfg.table}.${f.name as string}`,
+          `cannot query on non-indexed property: ${this.cfg.table}.${f.name}`,
           {
             query: q.pretty(),
           },
@@ -1234,7 +1255,7 @@ export class CommonDao<
       for (const f of q._filters) {
         _assert(
           f.name === 'id' || indexes.includes(f.name),
-          `cannot query on non-indexed property: ${this.cfg.table}.${f.name as string}`,
+          `cannot query on non-indexed property: ${this.cfg.table}.${f.name}`,
           {
             query: q.pretty(),
           },

--- a/packages/db-lib/src/commondao/common.dao.ts
+++ b/packages/db-lib/src/commondao/common.dao.ts
@@ -51,6 +51,7 @@ import type {
   CommonDaoStreamSaveOptions,
 } from './common.dao.model.js'
 import { CommonDaoTransaction } from './commonDaoTransaction.js'
+import type { ExcludePathSpec } from './excludePath.js'
 import { compileExcludePath, ExcludeFromIndexesBuilder } from './excludePath.js'
 
 /**
@@ -105,10 +106,12 @@ export class CommonDao<
 
     // Compile the user-provided array or builder function into a flat string[] used by the rest of the DAO.
     if (this.cfg.excludeFromIndexes) {
-      const specs =
-        typeof this.cfg.excludeFromIndexes === 'function'
-          ? this.cfg.excludeFromIndexes(new ExcludeFromIndexesBuilder<DBM>())
-          : this.cfg.excludeFromIndexes
+      let specs: ExcludePathSpec<DBM>[]
+      if (typeof this.cfg.excludeFromIndexes === 'function') {
+        specs = this.cfg.excludeFromIndexes(new ExcludeFromIndexesBuilder<DBM>())
+      } else {
+        specs = this.cfg.excludeFromIndexes
+      }
       this.compiledExcludeFromIndexes = specs.map(compileExcludePath)
     }
 
@@ -118,7 +121,7 @@ export class CommonDao<
 
     // If auto-compression is enabled, ensure '__compressed' is part of the exclusion list.
     if (this.cfg.compress?.keys) {
-      this.compiledExcludeFromIndexes ??= []
+      this.compiledExcludeFromIndexes ||= []
       if (!this.compiledExcludeFromIndexes.includes('__compressed')) {
         this.compiledExcludeFromIndexes.push('__compressed')
       }
@@ -579,17 +582,15 @@ export class CommonDao<
   private prepareSaveOptions(
     opt: CommonDaoSaveOptions<BM, DBM>,
   ): CommonDBSaveOptions<ObjectWithId> {
-    let {
-      saveMethod,
-      assignGeneratedIds = this.cfg.assignGeneratedIds,
-      excludeFromIndexes = this.compiledExcludeFromIndexes,
-    } = opt
+    let { saveMethod, assignGeneratedIds = this.cfg.assignGeneratedIds } = opt
+    const isExcludeFromIndexesOverride = opt.excludeFromIndexes !== undefined
+    let excludeFromIndexes = opt.excludeFromIndexes || this.compiledExcludeFromIndexes
 
     // If the user passed in a custom `excludeFromIndexes` with the save() call,
     // and the auto-compression is enabled,
     // then we need to ensure that the '__compressed' property is part of the list.
-    if (this.cfg.compress?.keys && excludeFromIndexes !== this.compiledExcludeFromIndexes) {
-      excludeFromIndexes ??= []
+    if (this.cfg.compress?.keys && isExcludeFromIndexesOverride) {
+      excludeFromIndexes ||= []
       if (!excludeFromIndexes.includes('__compressed' as any)) {
         excludeFromIndexes.push('__compressed' as any)
       }

--- a/packages/db-lib/src/commondao/excludePath.test.ts
+++ b/packages/db-lib/src/commondao/excludePath.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'vitest'
+import { compileExcludePath, createExcludeBuilder } from './excludePath.js'
+
+interface Sample {
+  id: string
+  title: string
+  meta?: { author: string; status: string }
+  config?: { theme: string }
+  tags?: { label: string; score: number }[]
+}
+
+const ex = createExcludeBuilder<Sample>()
+
+describe('createExcludeBuilder', () => {
+  test('should build a NestedSpec tagged object', () => {
+    expect(ex.nested('meta', 'author')).toEqual({
+      type: 'nested',
+      field: 'meta',
+      subPath: 'author',
+    })
+  })
+
+  test('should build a WildcardSpec tagged object', () => {
+    expect(ex.wildcard('config')).toEqual({
+      type: 'wildcard',
+      field: 'config',
+    })
+  })
+
+  test('should build an ElementSpec with default "*" matchProperty', () => {
+    expect(ex.element('tags')).toEqual({
+      type: 'element',
+      arrayName: 'tags',
+      matchProperty: '*',
+    })
+  })
+
+  test('should build an ElementSpec with explicit matchProperty', () => {
+    expect(ex.element('tags', 'label')).toEqual({
+      type: 'element',
+      arrayName: 'tags',
+      matchProperty: 'label',
+    })
+  })
+})
+
+describe('compileExcludePath', () => {
+  test('should return the input verbatim for a top-level key string', () => {
+    expect(compileExcludePath<Sample>('title')).toBe('title')
+  })
+
+  test('should produce "field.subPath" for a nested spec', () => {
+    expect(compileExcludePath(ex.nested('meta', 'author'))).toBe('meta.author')
+  })
+
+  test('should produce "field.*" for a wildcard spec', () => {
+    expect(compileExcludePath(ex.wildcard('config'))).toBe('config.*')
+  })
+
+  test('should produce "arrayName[].*" for an element spec with default matchProperty', () => {
+    expect(compileExcludePath(ex.element('tags'))).toBe('tags[].*')
+  })
+
+  test('should produce "arrayName[].property" for an element spec with explicit matchProperty', () => {
+    expect(compileExcludePath(ex.element('tags', 'label'))).toBe('tags[].label')
+  })
+})
+
+describe('type-level constraints', () => {
+  test('should reject nested() on a primitive key', () => {
+    // @ts-expect-error title is a string, not an object
+    ex.nested('title', 'foo')
+  })
+
+  test('should reject nested() on an array key', () => {
+    // @ts-expect-error tags is an array, not a nested object
+    ex.nested('tags', 'label')
+  })
+
+  test('should reject nested() with a sub-path that does not exist on the field', () => {
+    // @ts-expect-error 'notAKey' is not a key of meta
+    ex.nested('meta', 'notAKey')
+  })
+
+  test('should reject wildcard() on a primitive key', () => {
+    // @ts-expect-error title is a string, not an object
+    ex.wildcard('title')
+  })
+
+  test('should reject wildcard() on an array key', () => {
+    // @ts-expect-error tags is an array, not a nested object
+    ex.wildcard('tags')
+  })
+
+  test('should reject element() on a non-array key', () => {
+    // @ts-expect-error meta is an object, not an array
+    ex.element('meta')
+  })
+
+  test('should reject element() with a matchProperty that does not exist on the array element', () => {
+    // @ts-expect-error 'notAKey' is not a key of a tag
+    ex.element('tags', 'notAKey')
+  })
+})

--- a/packages/db-lib/src/commondao/excludePath.test.ts
+++ b/packages/db-lib/src/commondao/excludePath.test.ts
@@ -1,20 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { compileExcludePath, ExcludeFromIndexesBuilder } from './excludePath.js'
 
-interface Inner {
-  name: string
-  age: number
-}
-
-interface Sample {
-  id: string
-  title: string
-  meta?: { author: string; status: string; profile?: Inner }
-  config?: { theme: string }
-  tags?: { label: string; score: number }[]
-  scores?: number[]
-}
-
 const ex = new ExcludeFromIndexesBuilder<Sample>()
 
 describe('compileExcludePath', () => {
@@ -68,17 +54,17 @@ describe('ExcludeFromIndexesBuilder.array', () => {
   })
 
   test('should chain after a nested `object` to reach an inner array', () => {
-    // contrived but exercises composition: meta has no array — use a fresh shape
-    interface WithNestedArray {
-      id: string
-      group?: { entries?: { label: string }[] }
-    }
     const exN = new ExcludeFromIndexesBuilder<WithNestedArray>()
     expect(exN.object('group').array('entries').property('label')).toEqual({
       type: 'path',
       path: 'group.entries[].label',
     })
   })
+
+  interface WithNestedArray {
+    id: string
+    group?: { entries?: { label: string }[] }
+  }
 })
 
 describe('ExcludeFromIndexesBuilder type constraints', () => {
@@ -135,21 +121,6 @@ describe('ExcludeFromIndexesBuilder type constraints', () => {
 })
 
 describe('ExcludeFromIndexesBuilder with discriminated-union variants', () => {
-  interface VariantA {
-    kind: 'a'
-    sharedField: string
-    onlyOnA: string
-  }
-  interface VariantB {
-    kind: 'b'
-    sharedField: string
-    onlyOnB: number
-  }
-  interface WithUnion {
-    id: string
-    payload?: VariantA | VariantB
-  }
-
   const exU = new ExcludeFromIndexesBuilder<WithUnion>()
 
   test('should accept keys from any variant of a discriminated union', () => {
@@ -171,4 +142,33 @@ describe('ExcludeFromIndexesBuilder with discriminated-union variants', () => {
     // @ts-expect-error 'notAKey' is on neither variant
     exU.object('payload').property('notAKey')
   })
+
+  interface WithUnion {
+    id: string
+    payload?: VariantA | VariantB
+  }
+  interface VariantA {
+    kind: 'a'
+    sharedField: string
+    onlyOnA: string
+  }
+  interface VariantB {
+    kind: 'b'
+    sharedField: string
+    onlyOnB: number
+  }
 })
+
+interface Sample {
+  id: string
+  title: string
+  meta?: { author: string; status: string; profile?: Inner }
+  config?: { theme: string }
+  tags?: { label: string; score: number }[]
+  scores?: number[]
+}
+
+interface Inner {
+  name: string
+  age: number
+}

--- a/packages/db-lib/src/commondao/excludePath.test.ts
+++ b/packages/db-lib/src/commondao/excludePath.test.ts
@@ -1,104 +1,174 @@
 import { describe, expect, test } from 'vitest'
-import { compileExcludePath, createExcludeBuilder } from './excludePath.js'
+import { compileExcludePath, ExcludeFromIndexesBuilder } from './excludePath.js'
+
+interface Inner {
+  name: string
+  age: number
+}
 
 interface Sample {
   id: string
   title: string
-  meta?: { author: string; status: string }
+  meta?: { author: string; status: string; profile?: Inner }
   config?: { theme: string }
   tags?: { label: string; score: number }[]
+  scores?: number[]
 }
 
-const ex = createExcludeBuilder<Sample>()
-
-describe('createExcludeBuilder', () => {
-  test('should build a NestedSpec tagged object', () => {
-    expect(ex.nested('meta', 'author')).toEqual({
-      type: 'nested',
-      field: 'meta',
-      subPath: 'author',
-    })
-  })
-
-  test('should build a WildcardSpec tagged object', () => {
-    expect(ex.wildcard('config')).toEqual({
-      type: 'wildcard',
-      field: 'config',
-    })
-  })
-
-  test('should build an ElementSpec with default "*" matchProperty', () => {
-    expect(ex.element('tags')).toEqual({
-      type: 'element',
-      arrayName: 'tags',
-      matchProperty: '*',
-    })
-  })
-
-  test('should build an ElementSpec with explicit matchProperty', () => {
-    expect(ex.element('tags', 'label')).toEqual({
-      type: 'element',
-      arrayName: 'tags',
-      matchProperty: 'label',
-    })
-  })
-})
+const ex = new ExcludeFromIndexesBuilder<Sample>()
 
 describe('compileExcludePath', () => {
   test('should return the input verbatim for a top-level key string', () => {
     expect(compileExcludePath<Sample>('title')).toBe('title')
   })
 
-  test('should produce "field.subPath" for a nested spec', () => {
-    expect(compileExcludePath(ex.nested('meta', 'author'))).toBe('meta.author')
-  })
-
-  test('should produce "field.*" for a wildcard spec', () => {
-    expect(compileExcludePath(ex.wildcard('config'))).toBe('config.*')
-  })
-
-  test('should produce "arrayName[].*" for an element spec with default matchProperty', () => {
-    expect(compileExcludePath(ex.element('tags'))).toBe('tags[].*')
-  })
-
-  test('should produce "arrayName[].property" for an element spec with explicit matchProperty', () => {
-    expect(compileExcludePath(ex.element('tags', 'label'))).toBe('tags[].label')
+  test('should return the wrapped path for a PathSpec', () => {
+    const spec = ex.object('meta').property('author')
+    expect(compileExcludePath<Sample>(spec)).toBe('meta.author')
   })
 })
 
-describe('type-level constraints', () => {
-  test('should reject nested() on a primitive key', () => {
+describe('ExcludeFromIndexesBuilder.object', () => {
+  test('should produce a PathSpec equivalent to a top-level wildcard', () => {
+    expect(ex.object('meta').wildcard()).toEqual({ type: 'path', path: 'meta.*' })
+  })
+
+  test('should produce a PathSpec equivalent to a one-level nested property', () => {
+    expect(ex.object('meta').property('author')).toEqual({ type: 'path', path: 'meta.author' })
+  })
+
+  test('should chain `object` for deeper nesting', () => {
+    expect(ex.object('meta').object('profile').property('name')).toEqual({
+      type: 'path',
+      path: 'meta.profile.name',
+    })
+  })
+
+  test('should chain `object` then terminate with `wildcard`', () => {
+    expect(ex.object('meta').object('profile').wildcard()).toEqual({
+      type: 'path',
+      path: 'meta.profile.*',
+    })
+  })
+})
+
+describe('ExcludeFromIndexesBuilder.array', () => {
+  test('should descend into an array and terminate at a property', () => {
+    expect(ex.array('tags').property('label')).toEqual({
+      type: 'path',
+      path: 'tags[].label',
+    })
+  })
+
+  test('should descend into an array and terminate with wildcard', () => {
+    expect(ex.array('tags').wildcard()).toEqual({
+      type: 'path',
+      path: 'tags[].*',
+    })
+  })
+
+  test('should chain after a nested `object` to reach an inner array', () => {
+    // contrived but exercises composition: meta has no array — use a fresh shape
+    interface WithNestedArray {
+      id: string
+      group?: { entries?: { label: string }[] }
+    }
+    const exN = new ExcludeFromIndexesBuilder<WithNestedArray>()
+    expect(exN.object('group').array('entries').property('label')).toEqual({
+      type: 'path',
+      path: 'group.entries[].label',
+    })
+  })
+})
+
+describe('ExcludeFromIndexesBuilder type constraints', () => {
+  test('should reject `object` on a primitive top-level key', () => {
     // @ts-expect-error title is a string, not an object
-    ex.nested('title', 'foo')
+    ex.object('title')
   })
 
-  test('should reject nested() on an array key', () => {
-    // @ts-expect-error tags is an array, not a nested object
-    ex.nested('tags', 'label')
+  test('should reject `object` on an array key', () => {
+    // @ts-expect-error tags is an array — use `.array(...)` instead
+    ex.object('tags')
   })
 
-  test('should reject nested() with a sub-path that does not exist on the field', () => {
+  test('should reject `object` on a deeper primitive key', () => {
+    // @ts-expect-error meta.author is a string
+    ex.object('meta').object('author')
+  })
+
+  test('should reject `object` with a non-existent key', () => {
+    // @ts-expect-error 'notAKey' is not a key of Sample
+    ex.object('notAKey')
+  })
+
+  test('should reject `array` on a non-array key', () => {
+    // @ts-expect-error meta is an object — use `.object(...)` instead
+    ex.array('meta')
+  })
+
+  test('should reject `property` at the root (no prefix yet)', () => {
+    // @ts-expect-error cannot terminate at the root
+    ex.property('title')
+  })
+
+  test('should reject `wildcard` at the root (no prefix yet)', () => {
+    // @ts-expect-error cannot terminate at the root
+    ex.wildcard()
+  })
+
+  test('should reject `property` with a non-existent sub-key', () => {
     // @ts-expect-error 'notAKey' is not a key of meta
-    ex.nested('meta', 'notAKey')
+    ex.object('meta').property('notAKey')
   })
 
-  test('should reject wildcard() on a primitive key', () => {
-    // @ts-expect-error title is a string, not an object
-    ex.wildcard('title')
+  test('should reject `wildcard` on a primitive-element array scope', () => {
+    // After `.array('scores')`, current is `number` (primitive).
+    // @ts-expect-error wildcard is meaningless on primitive elements
+    ex.array('scores').wildcard()
   })
 
-  test('should reject wildcard() on an array key', () => {
-    // @ts-expect-error tags is an array, not a nested object
-    ex.wildcard('tags')
+  test('should reject `property` on a primitive-element array scope', () => {
+    // @ts-expect-error number has no meaningful object keys for exclusion
+    ex.array('scores').property('toFixed')
+  })
+})
+
+describe('ExcludeFromIndexesBuilder with discriminated-union variants', () => {
+  interface VariantA {
+    kind: 'a'
+    sharedField: string
+    onlyOnA: string
+  }
+  interface VariantB {
+    kind: 'b'
+    sharedField: string
+    onlyOnB: number
+  }
+  interface WithUnion {
+    id: string
+    payload?: VariantA | VariantB
+  }
+
+  const exU = new ExcludeFromIndexesBuilder<WithUnion>()
+
+  test('should accept keys from any variant of a discriminated union', () => {
+    expect(exU.object('payload').property('onlyOnA')).toEqual({
+      type: 'path',
+      path: 'payload.onlyOnA',
+    })
+    expect(exU.object('payload').property('onlyOnB')).toEqual({
+      type: 'path',
+      path: 'payload.onlyOnB',
+    })
+    expect(exU.object('payload').property('sharedField')).toEqual({
+      type: 'path',
+      path: 'payload.sharedField',
+    })
   })
 
-  test('should reject element() on a non-array key', () => {
-    // @ts-expect-error meta is an object, not an array
-    ex.element('meta')
-  })
-
-  test('should reject element() with a matchProperty that does not exist on the array element', () => {
-    // @ts-expect-error 'notAKey' is not a key of a tag
-    ex.element('tags', 'notAKey')
+  test('should reject keys that exist on no variant', () => {
+    // @ts-expect-error 'notAKey' is on neither variant
+    exU.object('payload').property('notAKey')
   })
 })

--- a/packages/db-lib/src/commondao/excludePath.ts
+++ b/packages/db-lib/src/commondao/excludePath.ts
@@ -1,46 +1,6 @@
 import type { KeysMatching, Primitive, UnionKeyOf } from '@naturalcycles/js-lib/types'
 
 /**
- * Compiles a single `ExcludePathSpec` into the dotted/wildcard string form that the
- * underlying CommonDB layer expects (e.g. `'meta.author'`, `'config.*'`, `'tags[].*'`).
- */
-export function compileExcludePath<T>(spec: ExcludePathSpec<T>): string {
-  if (typeof spec === 'string') return spec
-  return spec.path
-}
-
-type ArrayElem<T> = T extends readonly (infer U)[] ? U : never
-type PrimitiveKeys<T> = KeysMatching<T, Primitive>
-type ArrayKeys<T> = KeysMatching<T, readonly unknown[]>
-type ObjectKeys<T> = Exclude<keyof T & string, PrimitiveKeys<T> | ArrayKeys<T>>
-// String keys of T's non-nullable value, distributed over unions. `never` if T is primitive
-// or array-typed, so call sites get a clean "not assignable to never" error instead of
-// `keyof string`/`keyof Array` noise (`'toFixed'`, `'push'`, etc.).
-type PropertyKeysOf<T> = [NonNullable<T>] extends [Primitive | readonly unknown[]]
-  ? never
-  : UnionKeyOf<NonNullable<T>> & string
-// Append a path segment to a prefix, handling the root (empty-prefix) case.
-type Join<P extends string, S extends string> = P extends '' ? S : `${P}.${S}`
-
-/**
- * Path expression for a single entry in `CommonDaoCfg.excludeFromIndexes`.
- *
- * - A plain `string` key for top-level fields (e.g. `'title'`).
- * - A `PathSpec` produced by the `ExcludeFromIndexesBuilder` chain for nested,
- *   wildcard, and array-element paths.
- */
-export type ExcludePathSpec<T> = (keyof T & string) | PathSpec
-
-/**
- * Free-form compiled path (e.g. `'meta.author.name'`, `'tags[].*'`). Produced by the
- * `ExcludeFromIndexesBuilder` chain. Consumers don't construct this directly.
- */
-export interface PathSpec {
-  readonly type: 'path'
-  readonly path: string
-}
-
-/**
  * Fluent builder for typed exclusion paths.
  *
  * Received as `ex` inside the function form of `CommonDaoCfg.excludeFromIndexes`.
@@ -116,4 +76,44 @@ export class ExcludeFromIndexesBuilder<Current, Prefix extends string = ''> {
   ): PathSpec {
     return { type: 'path', path: `${this.prefix}.*` }
   }
+}
+
+/**
+ * Compiles a single `ExcludePathSpec` into the dotted/wildcard string form that the
+ * underlying CommonDB layer expects (e.g. `'meta.author'`, `'config.*'`, `'tags[].*'`).
+ */
+export function compileExcludePath<T>(spec: ExcludePathSpec<T>): string {
+  if (typeof spec === 'string') return spec
+  return spec.path
+}
+
+type ObjectKeys<T> = Exclude<keyof T & string, PrimitiveKeys<T> | ArrayKeys<T>>
+type PrimitiveKeys<T> = KeysMatching<T, Primitive>
+type ArrayKeys<T> = KeysMatching<T, readonly unknown[]>
+// String keys of T's non-nullable value, distributed over unions. `never` if T is primitive
+// or array-typed, so call sites get a clean "not assignable to never" error instead of
+// `keyof string`/`keyof Array` noise (`'toFixed'`, `'push'`, etc.).
+type PropertyKeysOf<T> = [NonNullable<T>] extends [Primitive | readonly unknown[]]
+  ? never
+  : UnionKeyOf<NonNullable<T>> & string
+// Append a path segment to a prefix, handling the root (empty-prefix) case.
+type Join<P extends string, S extends string> = P extends '' ? S : `${P}.${S}`
+type ArrayElem<T> = T extends readonly (infer U)[] ? U : never
+
+/**
+ * Path expression for a single entry in `CommonDaoCfg.excludeFromIndexes`.
+ *
+ * - A plain `string` key for top-level fields (e.g. `'title'`).
+ * - A `PathSpec` produced by the `ExcludeFromIndexesBuilder` chain for nested,
+ *   wildcard, and array-element paths.
+ */
+export type ExcludePathSpec<T> = (keyof T & string) | PathSpec
+
+/**
+ * Free-form compiled path (e.g. `'meta.author.name'`, `'tags[].*'`). Produced by the
+ * `ExcludeFromIndexesBuilder` chain. Consumers don't construct this directly.
+ */
+export interface PathSpec {
+  readonly type: 'path'
+  readonly path: string
 }

--- a/packages/db-lib/src/commondao/excludePath.ts
+++ b/packages/db-lib/src/commondao/excludePath.ts
@@ -1,104 +1,119 @@
 import type { KeysMatching, Primitive, UnionKeyOf } from '@naturalcycles/js-lib/types'
 
 /**
- * Returns a builder for constructing type-safe `ExcludePathSpec` values for a given row type.
- * Pass the builder to `CommonDaoCfg.excludeFromIndexes` and use its methods to describe
- * nested, wildcard, and array-element paths. Top-level fields can be expressed as plain
- * string keys without going through the builder.
- *
- * @example
- *   excludeFromIndexes: ex => [
- *     'title',
- *     ex.nested('meta', 'author'),
- *     ex.wildcard('config'),
- *     ex.element('tags'),
- *   ]
- */
-export function createExcludeBuilder<T>(): ExcludeBuilder<T> {
-  return {
-    nested: (field, subPath) => ({ type: 'nested', field, subPath }),
-    wildcard: field => ({ type: 'wildcard', field }),
-    element: (arrayName, matchProperty = '*') => ({ type: 'element', arrayName, matchProperty }),
-  }
-}
-
-/**
  * Compiles a single `ExcludePathSpec` into the dotted/wildcard string form that the
- * underlying CommonDB layer expects (e.g. `'meta.author'`, `'config.*'`,
- * `'tags[].*'`).
+ * underlying CommonDB layer expects (e.g. `'meta.author'`, `'config.*'`, `'tags[].*'`).
  */
 export function compileExcludePath<T>(spec: ExcludePathSpec<T>): string {
   if (typeof spec === 'string') return spec
-  switch (spec.type) {
-    case 'nested': {
-      return `${spec.field}.${spec.subPath}`
-    }
-    case 'wildcard': {
-      return `${spec.field}.*`
-    }
-    case 'element': {
-      return `${spec.arrayName}[].${spec.matchProperty}`
-    }
-  }
+  return spec.path
 }
 
-type ObjectKeys<T> = Exclude<keyof T & string, PrimitiveKeys<T> | ArrayKeys<T>>
+type ArrayElem<T> = T extends readonly (infer U)[] ? U : never
 type PrimitiveKeys<T> = KeysMatching<T, Primitive>
 type ArrayKeys<T> = KeysMatching<T, readonly unknown[]>
-type ArrayElem<T> = T extends readonly (infer U)[] ? U : never
-
-export interface ExcludeBuilder<T> {
-  /** Build a path of the form `field.subPath`. */
-  nested<K extends ObjectKeys<T>>(
-    field: K,
-    subPath: UnionKeyOf<NonNullable<T[K]>> & string,
-  ): NestedSpec<T>
-
-  /** Build a path of the form `field.*`. */
-  wildcard<K extends ObjectKeys<T>>(field: K): WildcardSpec<T>
-
-  /**
-   * Build a path of the form `arrayName[].matchProperty`. `matchProperty` defaults
-   * to `'*'` (all properties of every element).
-   */
-  element<K extends ArrayKeys<T>>(
-    arrayName: K,
-    matchProperty?: (UnionKeyOf<NonNullable<ArrayElem<NonNullable<T[K]>>>> & string) | '*',
-  ): ElementSpec<T>
-}
+type ObjectKeys<T> = Exclude<keyof T & string, PrimitiveKeys<T> | ArrayKeys<T>>
+// String keys of T's non-nullable value, distributed over unions. `never` if T is primitive
+// or array-typed, so call sites get a clean "not assignable to never" error instead of
+// `keyof string`/`keyof Array` noise (`'toFixed'`, `'push'`, etc.).
+type PropertyKeysOf<T> = [NonNullable<T>] extends [Primitive | readonly unknown[]]
+  ? never
+  : UnionKeyOf<NonNullable<T>> & string
+// Append a path segment to a prefix, handling the root (empty-prefix) case.
+type Join<P extends string, S extends string> = P extends '' ? S : `${P}.${S}`
 
 /**
  * Path expression for a single entry in `CommonDaoCfg.excludeFromIndexes`.
  *
  * - A plain `string` key for top-level fields (e.g. `'title'`).
- * - A `NestedSpec`, `WildcardSpec`, or `ElementSpec` built via `createExcludeBuilder<T>()`
- *   for nested, wildcard, and array-element paths.
+ * - A `PathSpec` produced by the `ExcludeFromIndexesBuilder` chain for nested,
+ *   wildcard, and array-element paths.
  */
-export type ExcludePathSpec<T> =
-  | (keyof T & string)
-  | NestedSpec<T>
-  | WildcardSpec<T>
-  | ElementSpec<T>
+export type ExcludePathSpec<T> = (keyof T & string) | PathSpec
 
-/** Path of the form `field.subPath` (e.g. `'meta.author'`). */
-export interface NestedSpec<T> {
-  readonly type: 'nested'
-  readonly field: keyof T & string
-  readonly subPath: string
-}
-
-/** Path of the form `field.*` (e.g. `'config.*'`). */
-export interface WildcardSpec<T> {
-  readonly type: 'wildcard'
-  readonly field: keyof T & string
+/**
+ * Free-form compiled path (e.g. `'meta.author.name'`, `'tags[].*'`). Produced by the
+ * `ExcludeFromIndexesBuilder` chain. Consumers don't construct this directly.
+ */
+export interface PathSpec {
+  readonly type: 'path'
+  readonly path: string
 }
 
 /**
- * Path of the form `arrayName[].matchProperty` (e.g. `'tags[].*'` or
- * `'tags[].label'`).
+ * Fluent builder for typed exclusion paths.
+ *
+ * Received as `ex` inside the function form of `CommonDaoCfg.excludeFromIndexes`.
+ *
+ * `.object(key)` and `.array(key)` return another builder anchored deeper in the path.
+ * `.property(key)` and `.wildcard()` return a finished `PathSpec` — you can't keep
+ * chaining past those.
+ *
+ * The class is not intended to be instantiated by consumers — `CommonDao` constructs the
+ * root instance and passes it in.
+ *
+ * @example
+ *   ex.object('meta').property('author')                  // 'meta.author'
+ *   ex.object('meta').wildcard()                          // 'meta.*'
+ *   ex.object('meta').object('author').property('name')   // 'meta.author.name'
+ *   ex.array('tags').property('label')                    // 'tags[].label'
+ *   ex.array('tags').wildcard()                           // 'tags[].*'
+ *   ex.object('meta').array('tags').property('label')     // 'meta.tags[].label'
  */
-export interface ElementSpec<T> {
-  readonly type: 'element'
-  readonly arrayName: keyof T & string
-  readonly matchProperty: string
+export class ExcludeFromIndexesBuilder<Current, Prefix extends string = ''> {
+  constructor(private readonly prefix: Prefix = '' as Prefix) {}
+
+  /**
+   * Descend into an object property. Returns a new builder anchored one level deeper.
+   * Only accepts keys whose value is an object (not primitive, not array).
+   */
+  object<K extends ObjectKeys<NonNullable<Current>>>(
+    key: K,
+  ): ExcludeFromIndexesBuilder<NonNullable<Current>[K], Join<Prefix, K>> {
+    const newPrefix = (this.prefix === '' ? key : `${this.prefix}.${key}`) as Join<Prefix, K>
+    return new ExcludeFromIndexesBuilder(newPrefix)
+  }
+
+  /**
+   * Descend into an array property and iterate its elements. Returns a new builder
+   * anchored at the element type. Only accepts keys whose value is an array.
+   */
+  array<K extends ArrayKeys<NonNullable<Current>>>(
+    key: K,
+  ): ExcludeFromIndexesBuilder<
+    ArrayElem<NonNullable<NonNullable<Current>[K]>>,
+    Join<Prefix, `${K}[]`>
+  > {
+    const newPrefix = (this.prefix === '' ? `${key}[]` : `${this.prefix}.${key}[]`) as Join<
+      Prefix,
+      `${K}[]`
+    >
+    return new ExcludeFromIndexesBuilder(newPrefix)
+  }
+
+  /**
+   * Returns a finished `PathSpec` for `${prefix}.${key}`. Not callable at the root
+   * (you must descend with `.object(...)` or `.array(...)` first) or on primitive/array
+   * scopes (which have no meaningful sub-keys).
+   */
+  property<K extends PropertyKeysOf<Current>>(
+    this: Prefix extends '' ? never : ExcludeFromIndexesBuilder<Current, Prefix>,
+    key: K,
+  ): PathSpec {
+    return { type: 'path', path: `${this.prefix}.${key}` }
+  }
+
+  /**
+   * Returns a finished `PathSpec` for `${prefix}.*`. Not callable at the root or on
+   * primitive/array scopes.
+   */
+  wildcard(
+    this: Prefix extends ''
+      ? never
+      : [NonNullable<Current>] extends [Primitive | readonly unknown[]]
+        ? never
+        : ExcludeFromIndexesBuilder<Current, Prefix>,
+  ): PathSpec {
+    return { type: 'path', path: `${this.prefix}.*` }
+  }
 }

--- a/packages/db-lib/src/commondao/excludePath.ts
+++ b/packages/db-lib/src/commondao/excludePath.ts
@@ -1,0 +1,104 @@
+import type { KeysMatching, Primitive, UnionKeyOf } from '@naturalcycles/js-lib/types'
+
+/**
+ * Returns a builder for constructing type-safe `ExcludePathSpec` values for a given row type.
+ * Pass the builder to `CommonDaoCfg.excludeFromIndexes` and use its methods to describe
+ * nested, wildcard, and array-element paths. Top-level fields can be expressed as plain
+ * string keys without going through the builder.
+ *
+ * @example
+ *   excludeFromIndexes: ex => [
+ *     'title',
+ *     ex.nested('meta', 'author'),
+ *     ex.wildcard('config'),
+ *     ex.element('tags'),
+ *   ]
+ */
+export function createExcludeBuilder<T>(): ExcludeBuilder<T> {
+  return {
+    nested: (field, subPath) => ({ type: 'nested', field, subPath }),
+    wildcard: field => ({ type: 'wildcard', field }),
+    element: (arrayName, matchProperty = '*') => ({ type: 'element', arrayName, matchProperty }),
+  }
+}
+
+/**
+ * Compiles a single `ExcludePathSpec` into the dotted/wildcard string form that the
+ * underlying CommonDB layer expects (e.g. `'meta.author'`, `'config.*'`,
+ * `'tags[].*'`).
+ */
+export function compileExcludePath<T>(spec: ExcludePathSpec<T>): string {
+  if (typeof spec === 'string') return spec
+  switch (spec.type) {
+    case 'nested': {
+      return `${spec.field}.${spec.subPath}`
+    }
+    case 'wildcard': {
+      return `${spec.field}.*`
+    }
+    case 'element': {
+      return `${spec.arrayName}[].${spec.matchProperty}`
+    }
+  }
+}
+
+type ObjectKeys<T> = Exclude<keyof T & string, PrimitiveKeys<T> | ArrayKeys<T>>
+type PrimitiveKeys<T> = KeysMatching<T, Primitive>
+type ArrayKeys<T> = KeysMatching<T, readonly unknown[]>
+type ArrayElem<T> = T extends readonly (infer U)[] ? U : never
+
+export interface ExcludeBuilder<T> {
+  /** Build a path of the form `field.subPath`. */
+  nested<K extends ObjectKeys<T>>(
+    field: K,
+    subPath: UnionKeyOf<NonNullable<T[K]>> & string,
+  ): NestedSpec<T>
+
+  /** Build a path of the form `field.*`. */
+  wildcard<K extends ObjectKeys<T>>(field: K): WildcardSpec<T>
+
+  /**
+   * Build a path of the form `arrayName[].matchProperty`. `matchProperty` defaults
+   * to `'*'` (all properties of every element).
+   */
+  element<K extends ArrayKeys<T>>(
+    arrayName: K,
+    matchProperty?: (UnionKeyOf<NonNullable<ArrayElem<NonNullable<T[K]>>>> & string) | '*',
+  ): ElementSpec<T>
+}
+
+/**
+ * Path expression for a single entry in `CommonDaoCfg.excludeFromIndexes`.
+ *
+ * - A plain `string` key for top-level fields (e.g. `'title'`).
+ * - A `NestedSpec`, `WildcardSpec`, or `ElementSpec` built via `createExcludeBuilder<T>()`
+ *   for nested, wildcard, and array-element paths.
+ */
+export type ExcludePathSpec<T> =
+  | (keyof T & string)
+  | NestedSpec<T>
+  | WildcardSpec<T>
+  | ElementSpec<T>
+
+/** Path of the form `field.subPath` (e.g. `'meta.author'`). */
+export interface NestedSpec<T> {
+  readonly type: 'nested'
+  readonly field: keyof T & string
+  readonly subPath: string
+}
+
+/** Path of the form `field.*` (e.g. `'config.*'`). */
+export interface WildcardSpec<T> {
+  readonly type: 'wildcard'
+  readonly field: keyof T & string
+}
+
+/**
+ * Path of the form `arrayName[].matchProperty` (e.g. `'tags[].*'` or
+ * `'tags[].label'`).
+ */
+export interface ElementSpec<T> {
+  readonly type: 'element'
+  readonly arrayName: keyof T & string
+  readonly matchProperty: string
+}

--- a/packages/db-lib/src/commondao/index.ts
+++ b/packages/db-lib/src/commondao/index.ts
@@ -1,3 +1,4 @@
 export * from './common.dao.js'
 export * from './common.dao.model.js'
 export * from './commonDaoTransaction.js'
+export * from './excludePath.js'

--- a/packages/db-lib/src/commondao/index.ts
+++ b/packages/db-lib/src/commondao/index.ts
@@ -1,4 +1,4 @@
 export * from './common.dao.js'
 export * from './common.dao.model.js'
 export * from './commonDaoTransaction.js'
-export * from './excludePath.js'
+export type { ExcludeFromIndexesBuilder, ExcludePathSpec, PathSpec } from './excludePath.js'

--- a/packages/db-lib/src/inmemory/queryInMemory.ts
+++ b/packages/db-lib/src/inmemory/queryInMemory.ts
@@ -25,7 +25,7 @@ export function queryInMemory<ROW extends ObjectWithId>(q: DBQuery<ROW>, rows: R
   // oxlint-disable-next-line unicorn/no-array-reduce
   rows = q._filters.reduce((rows, filter) => {
     return rows.filter(row => {
-      const value = _get(row, filter.name as string)
+      const value = _get(row, filter.name)
       return FILTER_FNS[filter.op](value, filter.val)
     })
   }, rows)

--- a/packages/db-lib/src/query/dbQuery.ts
+++ b/packages/db-lib/src/query/dbQuery.ts
@@ -56,13 +56,13 @@ export const dbQueryFilterOperatorValues: DBQueryFilterOperator[] = [
 ]
 
 export interface DBQueryFilter<ROW extends ObjectWithId> {
-  name: keyof ROW
+  name: keyof ROW & string
   op: DBQueryFilterOperator
   val: any
 }
 
 export interface DBQueryOrder<ROW extends ObjectWithId> {
-  name: keyof ROW
+  name: keyof ROW & string
   descending?: boolean
 }
 
@@ -108,17 +108,17 @@ export class DBQuery<ROW extends ObjectWithId> {
   _groupByFieldNames?: (keyof ROW)[]
   _distinct = false
 
-  filter(name: keyof ROW, op: DBQueryFilterOperator, val: any): this {
+  filter(name: keyof ROW & string, op: DBQueryFilterOperator, val: any): this {
     this._filters.push({ name, op, val })
     return this
   }
 
-  filterEq(name: keyof ROW, val: any): this {
+  filterEq(name: keyof ROW & string, val: any): this {
     this._filters.push({ name, op: '==', val })
     return this
   }
 
-  filterIn(name: keyof ROW, val: any[]): this {
+  filterIn(name: keyof ROW & string, val: any[]): this {
     this._filters.push({ name, op: 'in', val })
     return this
   }
@@ -136,7 +136,7 @@ export class DBQuery<ROW extends ObjectWithId> {
     return this
   }
 
-  order(name: keyof ROW, descending?: boolean): this {
+  order(name: keyof ROW & string, descending?: boolean): this {
     this._orders.push({
       name,
       descending,
@@ -201,8 +201,8 @@ export class DBQuery<ROW extends ObjectWithId> {
     }
 
     tokens.push(
-      ...this._filters.map(f => `${f.name as string}${f.op}${f.val}`),
-      ...this._orders.map(o => `order by ${o.name as string}${o.descending ? ' desc' : ''}`),
+      ...this._filters.map(f => `${f.name}${f.op}${f.val}`),
+      ...this._orders.map(o => `order by ${o.name}${o.descending ? ' desc' : ''}`),
     )
 
     if (this._groupByFieldNames) {

--- a/packages/db-lib/src/validation/index.ts
+++ b/packages/db-lib/src/validation/index.ts
@@ -29,14 +29,14 @@ export const dbQueryFilterOperatorSchema = j.enum(dbQueryFilterOperatorValues)
 
 export const dbQueryFilterSchema = <ROW extends ObjectWithId>() =>
   j.object<DBQueryFilter<ROW>>({
-    name: j.string().castAs<keyof ROW>(),
+    name: j.string().castAs<keyof ROW & string>(),
     op: dbQueryFilterOperatorSchema,
     val: anyValueSchema,
   })
 
 export const dbQueryOrderSchema = <ROW extends ObjectWithId>() =>
   j.object<DBQueryOrder<ROW>>({
-    name: j.string().castAs<keyof ROW>(),
+    name: j.string().castAs<keyof ROW & string>(),
     descending: j.boolean().optional(),
   })
 

--- a/packages/firestore-lib/src/query.util.ts
+++ b/packages/firestore-lib/src/query.util.ts
@@ -65,7 +65,7 @@ export function dbQueryToFirestoreQuery<ROW extends ObjectWithId>(
   return q
 }
 
-function mapName<ROW extends ObjectWithId>(name: keyof ROW): string | FieldPath {
+function mapName<ROW extends ObjectWithId>(name: keyof ROW & string): string | FieldPath {
   if (name === 'id') return FieldPath.documentId()
-  return name as string
+  return name
 }

--- a/packages/js-lib/src/types.test.ts
+++ b/packages/js-lib/src/types.test.ts
@@ -1,4 +1,4 @@
-import { expect, expectTypeOf, test } from 'vitest'
+import { describe, expect, expectTypeOf, test } from 'vitest'
 import { _stringMapValuesSorted } from './array/index.js'
 import { localTime } from './datetime/index.js'
 import { asUnixTimestamp, asUnixTimestamp2000 } from './error/index.js'
@@ -28,7 +28,9 @@ import type {
   Reviver,
   Saved,
   StringMap,
+  KeysMatching,
   SyncFunction,
+  UnionKeyOf,
   UnixTimestamp,
   Unsaved,
   UnsavedId,
@@ -408,4 +410,96 @@ test('asUnixTimestamp2000', () => {
   expect(() => asUnixTimestamp2000(tsInMillis)).toThrowErrorMatchingInlineSnapshot(
     `[AssertionError: Number is not a valid UnixTimestamp2000: 1657756800000]`,
   )
+})
+
+describe('UnionKeyOf', () => {
+  test('should return all keys for a single object type', () => {
+    interface Foo {
+      a: string
+      b: number
+    }
+    expectTypeOf<UnionKeyOf<Foo>>().toEqualTypeOf<'a' | 'b'>()
+  })
+
+  test('should return the union of keys from every union member', () => {
+    interface A {
+      foo: string
+      bar: number
+    }
+    interface B {
+      foo: string
+      baz: boolean
+    }
+    expectTypeOf<UnionKeyOf<A | B>>().toEqualTypeOf<'foo' | 'bar' | 'baz'>()
+  })
+
+  test('should differ from plain keyof, which returns only the shared keys of a union', () => {
+    interface A {
+      foo: string
+      bar: number
+    }
+    interface B {
+      foo: string
+      baz: boolean
+    }
+    expectTypeOf<keyof (A | B)>().toEqualTypeOf<'foo'>()
+    expectTypeOf<UnionKeyOf<A | B>>().toEqualTypeOf<'foo' | 'bar' | 'baz'>()
+  })
+
+  test('should handle discriminated unions', () => {
+    type Shape = { kind: 'circle'; radius: number } | { kind: 'square'; side: number }
+    expectTypeOf<UnionKeyOf<Shape>>().toEqualTypeOf<'kind' | 'radius' | 'side'>()
+  })
+
+  test('should return never for never', () => {
+    expectTypeOf<UnionKeyOf<never>>().toEqualTypeOf<never>()
+  })
+})
+
+describe('KeysMatching', () => {
+  test('should pick string keys whose value matches the condition', () => {
+    interface Foo {
+      a: string
+      b: number
+      c: string
+    }
+    expectTypeOf<KeysMatching<Foo, string>>().toEqualTypeOf<'a' | 'c'>()
+  })
+
+  test('should pick keys whose optional value matches after stripping undefined', () => {
+    interface Foo {
+      a: string[]
+      b?: number[]
+      c: { foo: number }
+    }
+    expectTypeOf<KeysMatching<Foo, readonly unknown[]>>().toEqualTypeOf<'a' | 'b'>()
+  })
+
+  test('should not distribute over union value types', () => {
+    // `foo`'s value is `string | number`. With distribution, both 'foo' would be
+    // picked for `string` and for `number`. The atomic `[X] extends [Y]` check
+    // requires the whole union to extend the condition.
+    interface Foo {
+      foo: string | number
+      bar: string
+    }
+    expectTypeOf<KeysMatching<Foo, string>>().toEqualTypeOf<'bar'>()
+    expectTypeOf<KeysMatching<Foo, string | number>>().toEqualTypeOf<'foo' | 'bar'>()
+  })
+
+  test('should compose with Exclude to express "object keys"', () => {
+    interface Foo {
+      a: string
+      b: { x: number }
+      c: number[]
+      d?: { y: string }
+    }
+    type ArrayKeys = KeysMatching<Foo, readonly unknown[]>
+    type PrimitiveKeys = KeysMatching<Foo, string | number | boolean>
+    type ObjectKeys = Exclude<keyof Foo & string, ArrayKeys | PrimitiveKeys>
+
+    expectTypeOf<ArrayKeys>().toEqualTypeOf<'c'>()
+    expectTypeOf<PrimitiveKeys>().toEqualTypeOf<'a'>()
+    expectTypeOf<ObjectKeys>().toEqualTypeOf<'b' | 'd'>()
+  })
 })

--- a/packages/js-lib/src/types.ts
+++ b/packages/js-lib/src/types.ts
@@ -215,6 +215,57 @@ export type ValuesOf<T extends readonly any[]> = T[number]
  */
 export type ValueOf<T> = T[keyof T]
 
+/**
+ * Distributive `keyof`: returns the union of keys from every member of a union type,
+ * rather than just their intersection.
+ *
+ * `keyof (A | B)` returns only the keys that exist on **both** `A` and `B`
+ * (the safe overlap, since a value of type `A | B` could be either).
+ * `UnionKeyOf<A | B>` returns `keyof A | keyof B` — every key that exists on
+ * **any** member of the union.
+ *
+ * Useful when working with discriminated unions where you need to refer to a key
+ * that only exists on one variant (e.g. exclusion paths, key-based lookups that
+ * tolerate missing properties at runtime).
+ *
+ * @example
+ *
+ * type A = { foo: string; bar: number }
+ * type B = { foo: string; baz: boolean }
+ *
+ * type CommonKeys = keyof (A | B)     // 'foo'
+ * type AllKeys = UnionKeyOf<A | B>    // 'foo' | 'bar' | 'baz'
+ */
+export type UnionKeyOf<T> = T extends T ? keyof T : never
+
+/**
+ * String keys of `T` whose non-nullable value extends `V`.
+ *
+ * - Strips `null | undefined` from the value before checking, so optional fields
+ *   are classified by their underlying value type.
+ * - Treats the value type atomically (does not distribute over unions on the
+ *   value side), so a key with value `string | number` is picked by
+ *   `KeysMatching<T, string | number>` but not by `KeysMatching<T, string>`.
+ * - Returns only string keys, dropping `number` and `symbol` keys.
+ *
+ * Useful for partitioning the keys of a type by the shape of their values.
+ *
+ * @example
+ *
+ * interface Foo {
+ *   a: string
+ *   b: number
+ *   c?: string
+ *   d: string[]
+ * }
+ *
+ * type StringKeys = KeysMatching<Foo, string>           // 'a' | 'c'
+ * type ArrayKeys = KeysMatching<Foo, readonly unknown[]> // 'd'
+ */
+export type KeysMatching<T, V> = {
+  [K in keyof T & string]: [NonNullable<T[K]>] extends [V] ? K : never
+}[keyof T & string]
+
 export type KeyValueTuple<K, V> = [key: K, value: V]
 
 // Exclude<something, undefined> is used here to support StringMap<OBJ> (because values of StringMap add `undefined`)

--- a/packages/mongo-lib/src/query.util.ts
+++ b/packages/mongo-lib/src/query.util.ts
@@ -29,7 +29,7 @@ export function dbQueryToMongoQuery<ROW extends ObjectWithId>(
   // filter
   // oxlint-disable-next-line unicorn/no-array-reduce
   const query = dbQuery._filters.reduce<Filter<ROW>>((q, f) => {
-    const fname = FNAME_MAP[f.name as string] || f.name
+    const fname = FNAME_MAP[f.name] || f.name
     q[fname as keyof Filter<ROW>] = {
       ...q[fname as keyof Filter<ROW>], // in case there is a "between" query
       [OP_MAP[f.op] || f.op]: f.val,
@@ -40,7 +40,7 @@ export function dbQueryToMongoQuery<ROW extends ObjectWithId>(
   // order
   // oxlint-disable-next-line unicorn/no-array-reduce
   options.sort = dbQuery._orders.reduce<Record<string, SortDirection>>((map, ord) => {
-    map[FNAME_MAP[ord.name as string] || (ord.name as string)] = ord.descending ? -1 : 1
+    map[FNAME_MAP[ord.name] || ord.name] = ord.descending ? -1 : 1
     return map
   }, {})
 

--- a/packages/mysql-lib/src/query.util.ts
+++ b/packages/mysql-lib/src/query.util.ts
@@ -233,7 +233,7 @@ function getWhereTokens(q: DBQuery<any>): string[] | null {
           // special treatment
 
           return [
-            mysql.escapeId(mapNameToMySQL(f.name as string)),
+            mysql.escapeId(mapNameToMySQL(f.name)),
             f.op === '==' ? 'IS NULL' : 'IS NOT NULL',
           ].join(' ')
         }
@@ -242,11 +242,11 @@ function getWhereTokens(q: DBQuery<any>): string[] | null {
           // special case for arrays
           if (!f.val.length) returnNull = true
 
-          return `${mysql.escapeId(mapNameToMySQL(f.name as string))} IN (${mysql.escape(f.val)})`
+          return `${mysql.escapeId(mapNameToMySQL(f.name))} IN (${mysql.escape(f.val)})`
         }
 
         return [
-          mysql.escapeId(mapNameToMySQL(f.name as string)),
+          mysql.escapeId(mapNameToMySQL(f.name)),
           OP_MAP[f.op] || f.op,
           mysql.escape(f.val),
         ].join(' ')


### PR DESCRIPTION
Problem: If we want fancy index exclusions we have to do stuff like `'arrayElement[].*' as any`. We went half-way and made the elements typed, but it made non-flat elements less ergonomic to represent than `string[]` typing would have

Solution: A DSL (😱) for building these in a type-safe manner.

Spoiler: In our codebases this will surface some excludeFromIndexes entries on properties we don't define in our types anymore.

There's a new signature to achieve this:
```ts
    const dao = new CommonDao<NestedItem>({
      table: TEST_TABLE_2,
      db,
      excludeFromIndexes: ex => [
        'name',
        ex.object('nested').property('foo'),
        ex.object('config').wildcard(),
        ex.array('tags').wildcard(),
        ex.array('tags').property('score'),
      ],
    })
```


The old simple array signature is still supported to remain unbreaking for a brief period, but it should be removed soon in favor of just `() => [...]`