### PR TITLE
feat(nodejs-lib): harden pipeline mapper typings

### DIFF
--- a/packages/nodejs-lib/src/stream/pipeline.test.ts
+++ b/packages/nodejs-lib/src/stream/pipeline.test.ts
@@ -1,4 +1,5 @@
 import { Readable } from 'node:stream'
+import { END } from '@naturalcycles/js-lib/types'
 import { expect, test } from 'vitest'
 import { Pipeline } from './pipeline.js'
 import type { ReadableTyped } from './stream.model.js'
@@ -14,6 +15,33 @@ test('Pipeline', async () => {
 
   // console.log(r)
   expect(r).toEqual(['p_1', 'p_2', 'p_3'])
+})
+
+test('forEach returning END aborts the source', async () => {
+  const seen: string[] = []
+
+  await Pipeline.from<string>(new HonestReadable(100, 'p')).forEach(
+    async item => {
+      seen.push(item)
+      if (seen.length >= 5) return END
+    },
+    { concurrency: 1 },
+  )
+
+  expect(seen.length).toBeGreaterThanOrEqual(5)
+  expect(seen.length).toBeLessThan(100)
+})
+
+test('forEachSync returning END aborts the source', async () => {
+  const seen: string[] = []
+
+  await Pipeline.from<string>(new HonestReadable(100, 'p')).forEachSync(item => {
+    seen.push(item)
+    if (seen.length >= 5) return END
+  })
+
+  expect(seen.length).toBeGreaterThanOrEqual(5)
+  expect(seen.length).toBeLessThan(100)
 })
 
 /**

--- a/packages/nodejs-lib/src/stream/pipeline.ts
+++ b/packages/nodejs-lib/src/stream/pipeline.ts
@@ -8,6 +8,7 @@ import { createAbortableSignal } from '@naturalcycles/js-lib'
 import { _passthroughPredicate } from '@naturalcycles/js-lib/types'
 import type {
   AbortableAsyncMapper,
+  AbortableMapper,
   AsyncIndexedMapper,
   AsyncPredicate,
   END,
@@ -437,7 +438,7 @@ export class Pipeline<T = unknown> {
   }
 
   async forEachSync(
-    fn: IndexedMapper<T, void | typeof END>,
+    fn: AbortableMapper<T, void>,
     opt: TransformMapSyncOptions<T, void> & TransformLogProgressOptions<T> = {},
   ): Promise<void> {
     this.transforms.push(

--- a/packages/nodejs-lib/src/stream/pipeline.ts
+++ b/packages/nodejs-lib/src/stream/pipeline.ts
@@ -236,12 +236,12 @@ export class Pipeline<T = unknown> {
     return this
   }
 
-  tap(fn: AsyncIndexedMapper<T, any>, opt?: TransformOptions): this {
+  tap(fn: AsyncIndexedMapper<T, void>, opt?: TransformOptions): this {
     this.transforms.push(transformTap(fn, opt))
     return this
   }
 
-  tapSync(fn: IndexedMapper<T, any>, opt?: TransformOptions): this {
+  tapSync(fn: IndexedMapper<T, void>, opt?: TransformOptions): this {
     this.transforms.push(transformTapSync(fn, opt))
     return this
   }
@@ -420,7 +420,7 @@ export class Pipeline<T = unknown> {
   }
 
   async forEach(
-    fn: AsyncIndexedMapper<T, void>,
+    fn: AsyncIndexedMapper<T, void | typeof END>,
     opt: TransformMapOptions<T, void> & TransformLogProgressOptions<T> = {},
   ): Promise<void> {
     this.transforms.push(
@@ -437,7 +437,7 @@ export class Pipeline<T = unknown> {
   }
 
   async forEachSync(
-    fn: IndexedMapper<T, void>,
+    fn: IndexedMapper<T, void | typeof END>,
     opt: TransformMapSyncOptions<T, void> & TransformLogProgressOptions<T> = {},
   ): Promise<void> {
     this.transforms.push(

--- a/packages/nodejs-lib/src/stream/pipeline.ts
+++ b/packages/nodejs-lib/src/stream/pipeline.ts
@@ -420,7 +420,7 @@ export class Pipeline<T = unknown> {
   }
 
   async forEach(
-    fn: AsyncIndexedMapper<T, void | typeof END>,
+    fn: AbortableAsyncMapper<T, void>,
     opt: TransformMapOptions<T, void> & TransformLogProgressOptions<T> = {},
   ): Promise<void> {
     this.transforms.push(


### PR DESCRIPTION
In practice we use `END` on `forEach` internally, I think the type should reflect it. Similarly, tap should do no transformation, so I think void is appropriate, and having void still allows stuff like `() => rows++` in db-lib