### PR TITLE
feat: fix bounding bug on NCweb

### DIFF
--- a/packages/js-lib/src/browser/adminService.ts
+++ b/packages/js-lib/src/browser/adminService.ts
@@ -86,6 +86,8 @@ export class AdminService {
 
   private listening = false
 
+  private readonly boundKeydownListener = this.keydownListener.bind(this)
+
   /**
    * Start listening to keyboard events to toggle AdminMode when detected.
    */
@@ -96,14 +98,14 @@ export class AdminService {
 
     if (this.adminMode) this.toggleRedDotVisibility()
 
-    document.addEventListener('keydown', this.keydownListener.bind(this), { passive: true })
+    document.addEventListener('keydown', this.boundKeydownListener, { passive: true })
 
     this.listening = true
   }
 
   stopListening(): void {
     if (isServerSide()) return
-    document.removeEventListener('keydown', this.keydownListener)
+    document.removeEventListener('keydown', this.boundKeydownListener)
     this.listening = false
   }
 


### PR DESCRIPTION
There is a bug on NCWeb where the cntrl shift L bugs out and can not be properly opened and closed. I made a quick fix on NCWeb in this branch: https://github.com/NaturalCycles/NCWeb/pull/4704 but thought I could fix it here... 

In dev, React StrictMode runs each effect twice on purpose on mount, cleanup, mount again to catch bugs like this one. Because cleanup couldn't remove the first listener, we ended up with two listeners on the page. I could see that every keypress fired both when console logging one flipped adminMode on, the other immediately flipped it back off, so nothing visibly changed. Production doesn't do this double thing with mount/cleanup, so only one listener was added and worked as expected

Dont know who to tag for this...